### PR TITLE
Standardize GEMINI_API_KEY variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,4 @@
 PORT=3001
 DATABASE_PATH=./bluimports.db
 JWT_SECRET=sua-chave-secreta
-API_KEY=sua-chave-gemini
+GEMINI_API_KEY=sua-chave-gemini

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ uma VPS do zero. Consulte a seção seguinte para detalhes adicionais.
    - `PORT` - porta do backend (ex.: 3001)
    - `DATABASE_PATH` - caminho do arquivo SQLite (ex.: `./bluimports.db`)
    - `JWT_SECRET` - chave secreta para gerar tokens
-   - `API_KEY` - chave da API Gemini
+   - `GEMINI_API_KEY` - chave da API Gemini
 
    ```bash
    cp .env.example .env
@@ -122,7 +122,7 @@ Após esses passos, a aplicação deve estar acessível via navegador.
         *   `PORT`: Port for the backend server (e.g., 3001).
         *   `DATABASE_PATH`: Path to your SQLite database file (e.g., `./bluimports.db` or an absolute path on your VPS).
         *   `JWT_SECRET`: **CRITICAL!** Generate a strong, random secret key for JWTs.
-        *   `API_KEY`: Your Google Gemini API key. This is now used securely by the backend.
+        *   `GEMINI_API_KEY`: Your Google Gemini API key. This is now used securely by the backend.
 
 4.  **Initialize Database (First time):**
     The `server/database.js` script attempts to create tables if they don't exist when the server starts or when run directly. You can also run it manually:

--- a/server/server.js
+++ b/server/server.js
@@ -10,7 +10,7 @@ const db = require('./database'); // Your SQLite database connection
 const app =express();
 const PORT = process.env.PORT || 3001;
 const JWT_SECRET = process.env.JWT_SECRET || 'your-fallback-jwt-secret-key'; // Fallback only, set in .env
-// const GEMINI_API_KEY = process.env.API_KEY; // For backend Gemini calls
+// const GEMINI_API_KEY = process.env.GEMINI_API_KEY; // For backend Gemini calls
 
 // if (GEMINI_API_KEY) {
 //   const ai = new GoogleGenAI({ apiKey: GEMINI_API_KEY });

--- a/services/AppService.tsx
+++ b/services/AppService.tsx
@@ -10,7 +10,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 // --- CONSTANTS ---
 export const APP_NAME = "Blu Imports Dashboard";
-// API_KEY is no longer client-side
+// GEMINI_API_KEY is no longer client-side
 
 export const ORDER_STATUS_OPTIONS: OrderStatus[] = Object.values(OrderStatus);
 export const PRODUCT_CONDITION_OPTIONS: ProductCondition[] = Object.values(ProductCondition);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,6 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
       },
       resolve: {


### PR DESCRIPTION
## Summary
- use `GEMINI_API_KEY` as the single variable name
- update docs and env example to reflect new name
- simplify `vite.config.ts` env injection
- adjust comments referring to the old key name

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409108fbf88322b572003a4f758835