### PR TITLE
Implement customer address fields and status updates

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -65,7 +65,7 @@ export const AddOrderCostModal: React.FC<AddOrderCostModalProps> = ({ isOpen, on
             setIsLoadingOrders(true);
             getOrders() // Use the corrected getOrders
                 .then(fetchedOrders => {
-                    const activeOrders = fetchedOrders.filter( o => o.status !== OrderStatus.CANCELADO && o.status !== OrderStatus.ENTREGUE ).sort((a,b) => new Date(b.orderDate).getTime() - new Date(a.orderDate).getTime()); 
+                    const activeOrders = fetchedOrders.filter( o => o.status !== OrderStatus.CANCELADO && o.status !== OrderStatus.ENVIADO ).sort((a,b) => new Date(b.orderDate).getTime() - new Date(a.orderDate).getTime());
                     setAllOrders(activeOrders);
                     setIsLoadingOrders(false);
                 })

--- a/features/BluFacilitaFeature.tsx
+++ b/features/BluFacilitaFeature.tsx
@@ -174,7 +174,7 @@ const ViewInstallmentsModal: React.FC<ViewInstallmentsModalProps> = ({ order, is
                 {item.status}
             </span>
         )},
-        { header: 'Valor Pago', accessor: (item: BluFacilitaInstallment): ReactNode => formatCurrencyBRL(item.amountPaid) },
+        { header: 'Custo Pago', accessor: (item: BluFacilitaInstallment): ReactNode => formatCurrencyBRL(item.amountPaid) },
         { header: 'Data Pag.', accessor: (item: BluFacilitaInstallment): ReactNode => formatDateBR(item.paymentDate) },
         { header: 'Obs.', accessor: 'notes' as keyof BluFacilitaInstallment, cellClassName: "text-xs max-w-xs whitespace-normal" },
     ];

--- a/features/ClientsFeature.tsx
+++ b/features/ClientsFeature.tsx
@@ -13,6 +13,8 @@ const initialFormData: Omit<Client, 'id' | 'registrationDate'> = {
   cpfOrCnpj: '',
   email: '',
   phone: '',
+  address: '',
+  cep: '',
   city: '',
   state: '',
   clientType: ClientType.PESSOA_FISICA,
@@ -108,6 +110,10 @@ const ClientForm: React.FC<ClientFormProps> = ({ isOpen, onClose, onSave, initia
             <Input label="E-mail" id="email" name="email" type="email" value={formData.email} onChange={handleChange} required />
             <Input label="Telefone" id="phone" name="phone" type="tel" value={formData.phone} onChange={handleChange} required placeholder="(00) 90000-0000" />
         </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+            <Input label="Endereço" id="address" name="address" value={formData.address} onChange={handleChange} />
+            <Input label="CEP" id="cep" name="cep" value={formData.cep} onChange={handleChange} />
+        </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <Input label="Cidade" id="city" name="city" value={formData.city} onChange={handleChange} />
             <Input label="Estado (UF)" id="state" name="state" value={formData.state} onChange={handleChange} maxLength={2} placeholder="Ex: SP, RJ" />
@@ -179,7 +185,7 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ client, isOpen,
                         <p><strong>CPF/CNPJ:</strong> {formatCPFOrCNPJ(client.cpfOrCnpj, client.clientType)} ({client.clientType})</p>
                         <p><strong>Email:</strong> {client.email}</p>
                         <p><strong>Telefone:</strong> {client.phone}</p>
-                        <p><strong>Endereço:</strong> {client.city ? `${client.city} - ${client.state}` : 'Não informado'}</p>
+                        <p><strong>Endereço:</strong> {client.address ? `${client.address}, ${client.city} - ${client.state}, CEP: ${client.cep}` : 'Não informado'}</p>
                         <p><strong>Cliente Desde:</strong> {formatDateBR(client.registrationDate)}</p>
                         {client.notes && <p className="md:col-span-2"><strong>Observações:</strong> {client.notes}</p>}
                     </div>
@@ -303,6 +309,8 @@ export const ClientsPage: React.FC<{}> = () => {
         TipoCliente: c.clientType,
         Email: c.email,
         Telefone: c.phone,
+        Endereco: c.address,
+        CEP: c.cep,
         Cidade: c.city,
         Estado: c.state,
         DataCadastro: formatDateBR(c.registrationDate),

--- a/features/FinancialReportsFeature.tsx
+++ b/features/FinancialReportsFeature.tsx
@@ -292,7 +292,7 @@ const MonthlySummaryTab: React.FC = () => {
                 const costsByType = Object.fromEntries(COST_TYPE_OPTIONS.map(type => [type, 0])) as Record<CostType, number>;
                 
                 allOrders.forEach(order => {
-                    const deliveryEntry = order.trackingHistory.find(h => h.status === OrderStatus.ENTREGUE);
+                    const deliveryEntry = order.trackingHistory.find(h => h.status === OrderStatus.ENVIADO);
                     if (deliveryEntry && deliveryEntry.date) { // Ensure date exists
                         const deliveryDate = new Date(deliveryEntry.date);
                         if (deliveryDate >= firstDayOfMonth && deliveryDate <= lastDayOfMonth) {

--- a/types.ts
+++ b/types.ts
@@ -1,20 +1,12 @@
 export enum OrderStatus {
-  PEDIDO_REALIZADO = 'Pedido Realizado',
+  PEDIDO_CRIADO = 'Pedido Criado',
   PAGAMENTO_CONFIRMADO = 'Pagamento Confirmado',
-  EM_PROCESSAMENTO = 'Em Processamento', // Fornecedor preparando
-  PEDIDO_ENVIADO = 'Pedido Enviado', // Enviado pelo fornecedor
-  EM_TRANSITO_INTERNACIONAL = 'Em Trânsito Internacional',
-  CHEGOU_HUB_LOGISTICO = 'Chegou ao Hub Logístico', // Ex: Miami, redirecionador
-  AGUARDANDO_ENVIO_BRASIL = 'Aguardando Envio para o Brasil',
-  EM_TRANSITO_BRASIL = 'Em Trânsito para o Brasil',
-  DESEMBARACO_ADUANEIRO = 'Desembaraço Aduaneiro',
-  LIBERADO_PELA_ALFANDEGA = 'Liberado pela Alfândega',
-  EM_ROTA_ENTREGA_FINAL = 'Em Rota para Entrega Final', // Já no Brasil
-  CHEGOU_NO_BRASIL = 'Chegou no Brasil', // Genérico se não detalhado
+  COMPRA_REALIZADA = 'Compra Realizada',
+  A_CAMINHO_DO_ESCRITORIO = 'A Caminho do Escritório',
+  CHEGOU_NO_ESCRITORIO = 'Chegou no Escritório',
   AGUARDANDO_RETIRADA = 'Aguardando Retirada',
-  ENTREGUE = 'Entregue',
+  ENVIADO = 'Enviado',
   CANCELADO = 'Cancelado',
-  PRONTO_PARA_ENTREGA = 'Pronto para Entrega', // Após registro de chegada
 }
 
 export enum ProductCondition {
@@ -161,6 +153,8 @@ export interface Client {
     cpfOrCnpj: string; 
     email: string;
     phone: string;
+    address: string;
+    cep: string;
     city: string;
     state: string; 
     clientType: ClientType;


### PR DESCRIPTION
## Summary
- rename purchase price labels to **Custo**
- add `address` and `cep` fields to clients
- drop duplicate client creation on order edit
- restrict product and storage to dropdown lists
- simplify order statuses and update timeline logic

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684706acc4248322a754647a603f2277