### PR TITLE
Add CEP autofill and 'Entregue' status

### DIFF
--- a/features/FinancialReportsFeature.tsx
+++ b/features/FinancialReportsFeature.tsx
@@ -292,7 +292,9 @@ const MonthlySummaryTab: React.FC = () => {
                 const costsByType = Object.fromEntries(COST_TYPE_OPTIONS.map(type => [type, 0])) as Record<CostType, number>;
                 
                 allOrders.forEach(order => {
-                    const deliveryEntry = order.trackingHistory.find(h => h.status === OrderStatus.ENVIADO);
+                    const deliveryEntry = order.trackingHistory.find(
+                        h => h.status === OrderStatus.ENTREGUE || h.status === OrderStatus.ENVIADO
+                    );
                     if (deliveryEntry && deliveryEntry.date) { // Ensure date exists
                         const deliveryDate = new Date(deliveryEntry.date);
                         if (deliveryDate >= firstDayOfMonth && deliveryDate <= lastDayOfMonth) {

--- a/types.ts
+++ b/types.ts
@@ -6,6 +6,7 @@ export enum OrderStatus {
   CHEGOU_NO_ESCRITORIO = 'Chegou no Escritório',
   AGUARDANDO_RETIRADA = 'Aguardando Retirada',
   ENVIADO = 'Enviado',
+  ENTREGUE = 'Entregue',
   CANCELADO = 'Cancelado',
 }
 


### PR DESCRIPTION
## Summary
- integrate ViaCEP and IBGE APIs to autofill address fields
- add dropdowns for state and city selections
- introduce new order status `Entregue`
- display new status in order list and timeline
- count delivered orders for reports

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68470cb7d1008322b264611c4cb8fd11