### PR TITLE
Improve client editing stability

### DIFF
--- a/components/SharedComponents.tsx
+++ b/components/SharedComponents.tsx
@@ -1,6 +1,33 @@
 
 import React, { ReactNode, useState } from 'react';
 
+// --- Simple Error Boundary to avoid blank pages on runtime errors ---
+interface ErrorBoundaryProps { children: ReactNode; }
+interface ErrorBoundaryState { hasError: boolean; error?: Error; }
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('ErrorBoundary caught an error', error, info);
+  }
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-6 text-red-700">
+          <p className="font-semibold">Ocorreu um erro inesperado.</p>
+          <pre className="whitespace-pre-wrap text-xs mt-2">{this.state.error?.message}</pre>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
 // --- Icon Component (Simple Wrapper for Heroicons classes) ---
 export const WhatsAppIcon = (props: React.SVGProps<SVGSVGElement>) => (
     <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
@@ -386,7 +413,7 @@ export const ResponsiveTable = <T extends object,>({
               onKeyDown={onRowClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') onRowClick(item); } : undefined} // Added keyboard interaction
             >
               {columns.map((col, colIndex) => (
-                <td key={colIndex} className={`px-6 py-4 whitespace-nowrap text-sm text-gray-700 ${col.className || ''} ${col.cellClassName || ''}`}> 
+                <td key={colIndex} className={`px-6 py-4 whitespace-normal break-words text-sm text-gray-700 ${col.className || ''} ${col.cellClassName || ''}`}>
                   {typeof col.accessor === 'function'
                     ? col.accessor(item, rowIndex)
                     : (item[col.accessor as keyof T] as ReactNode)} 

--- a/features/ClientsFeature.tsx
+++ b/features/ClientsFeature.tsx
@@ -5,7 +5,7 @@ import {
   getOrders, 
   CLIENT_TYPE_OPTIONS, formatCPFOrCNPJ, formatDateBR, formatCurrencyBRL, exportToCSV
 } from '../services/AppService';
-import { Button, Modal, Input, Select, Textarea, Card, PageTitle, Alert, ResponsiveTable, Spinner } from '../components/SharedComponents';
+import { Button, Modal, Input, Select, Textarea, Card, PageTitle, Alert, ResponsiveTable, Spinner, ErrorBoundary } from '../components/SharedComponents';
 import { v4 as uuidv4 } from 'uuid';
 
 const BRAZIL_STATES = [
@@ -302,7 +302,7 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ client, isOpen,
 };
 
 
-export const ClientsPage: React.FC<{}> = () => {
+const ClientsPageInner: React.FC = () => {
   const [clients, setClients] = useState<Client[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isFormOpen, setIsFormOpen] = useState(false);
@@ -461,3 +461,9 @@ export const ClientsPage: React.FC<{}> = () => {
     </div>
   );
 };
+
+export const ClientsPage: React.FC = () => (
+  <ErrorBoundary>
+    <ClientsPageInner />
+  </ErrorBoundary>
+);


### PR DESCRIPTION
## Summary
- add a small ErrorBoundary component
- wrap Clients page in the new boundary
- allow table cells to wrap text instead of truncating

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6847104da8548322b6158d0fa1bc5444