### PR TITLE
Implement multi-step order form

### DIFF
--- a/components/SharedComponents.tsx
+++ b/components/SharedComponents.tsx
@@ -460,3 +460,28 @@ export const Tabs: React.FC<TabsProps> = ({ children, className = '', navClassNa
     </nav>
   </div>
 );
+
+interface StepperProps {
+  steps: string[];
+  currentStep: number;
+}
+
+export const Stepper: React.FC<StepperProps> = ({ steps, currentStep }) => (
+  <div className="flex items-center justify-between mb-4">
+    {steps.map((step, idx) => (
+      <div key={idx} className="flex items-center flex-1">
+        <div
+          className={`flex items-center justify-center h-8 w-8 rounded-full text-sm font-semibold ${
+            idx <= currentStep ? 'bg-blue-600 text-white' : 'bg-gray-300 text-gray-600'
+          }`}
+        >
+          {idx + 1}
+        </div>
+        <span className={`ml-2 text-sm ${idx <= currentStep ? 'text-blue-600 font-medium' : 'text-gray-600'}`}>{step}</span>
+        {idx < steps.length - 1 && (
+          <div className={`flex-1 h-0.5 ${idx < currentStep ? 'bg-blue-600' : 'bg-gray-300'} mx-2`} />
+        )}
+      </div>
+    ))}
+  </div>
+);


### PR DESCRIPTION
## Summary
- add Stepper component
- split order form into steps for a less crowded modal

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68471315e3fc8322b98748d20b15ccd9