### PR TITLE
Fix client edit form initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 *.local
 .env
+server/database.sqlite
 
 # Editor directories and files
 .vscode/*

--- a/features/ClientsFeature.tsx
+++ b/features/ClientsFeature.tsx
@@ -68,7 +68,9 @@ const ClientForm: React.FC<ClientFormProps> = ({ isOpen, onClose, onSave, initia
   
   useEffect(() => {
     if (initialClient) {
+      // Merge with initialFormData to ensure optional fields exist
       setFormData({
+        ...initialFormData,
         ...initialClient,
         notes: initialClient.notes || '',
         defaulterNotes: initialClient.defaulterNotes || '',


### PR DESCRIPTION
## Summary
- ensure optional fields exist when editing a client
- ignore development SQLite database

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68472dc8f88883229dcfc17f753992e4