### PR TITLE
Implement client search and add order form step stubs

### DIFF
--- a/features/OrdersFeature.tsx
+++ b/features/OrdersFeature.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo, ReactNode, ChangeEvent } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, ReactNode, ChangeEvent, useReducer } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom'; 
 import { Order, OrderStatus, ProductCondition, DocumentFile, Client, PaymentMethod, PAYMENT_METHOD_OPTIONS, BLU_FACILITA_CONTRACT_STATUS_OPTIONS, BluFacilitaContractStatus, Supplier, SupplierOption, InternalNote, DEFAULT_BLU_FACILITA_ANNUAL_INTEREST_RATE, ClientType, ClientPayment } from '../types';
 import { 
@@ -15,7 +15,8 @@ import {
 import { Button, Modal, Input, Select, Textarea, Card, PageTitle, Alert, ResponsiveTable, Spinner, WhatsAppIcon, ClipboardDocumentIcon, Stepper, Toast } from '../components/SharedComponents';
 import { ClientForm } from './ClientsFeature';
 import { v4 as uuidv4 } from 'uuid';
-import { EyeIcon, EyeSlashIcon, RegisterPaymentModal } from '../App'; 
+import { EyeIcon, EyeSlashIcon, RegisterPaymentModal } from '../App';
+import ClientProductStep from './orders/steps/ClientProductStep';
 
 
 // Icons
@@ -187,6 +188,41 @@ const initialFormData: Omit<Order, 'id' | 'documents' | 'trackingHistory' | 'cus
   bluFacilitaUsesSpecialRate: false, bluFacilitaSpecialAnnualRate: undefined,
 };
 
+type BaseFormData = typeof initialFormData;
+export interface OrderFormState extends BaseFormData {
+  currentStep: number;
+}
+
+export type OrderFormAction =
+  | { type: 'UPDATE_FIELD'; field: keyof BaseFormData; value: any }
+  | { type: 'SET_CLIENT'; client: Partial<Client> }
+  | { type: 'SET_STATE_FROM_INITIAL'; data: OrderFormState }
+  | { type: 'NEXT_STEP' }
+  | { type: 'PREV_STEP' };
+
+const orderFormReducer = (state: OrderFormState, action: OrderFormAction): OrderFormState => {
+  switch (action.type) {
+    case 'UPDATE_FIELD':
+      return { ...state, [action.field]: action.value } as OrderFormState;
+    case 'SET_CLIENT':
+      return {
+        ...state,
+        clientId: action.client.id,
+        customerNameManual: action.client.id ? '' : action.client.fullName ?? ''
+      };
+    case 'SET_STATE_FROM_INITIAL':
+      return action.data;
+    case 'NEXT_STEP':
+      return { ...state, currentStep: state.currentStep + 1 };
+    case 'PREV_STEP':
+      return { ...state, currentStep: Math.max(0, state.currentStep - 1) };
+    default:
+      return state;
+  }
+};
+
+const initialState: OrderFormState = { ...initialFormData, currentStep: 0 };
+
 
 interface OrderFormProps { isOpen: boolean; onClose: () => void; onSave: (order: Order) => Promise<void>; initialOrder?: Order | null; prefillData?: Partial<OrderFormPrefillData>; }
 interface OrderFormPrefillData {
@@ -200,7 +236,8 @@ interface OrderFormPrefillData {
 
 
 const OrderForm: React.FC<OrderFormProps> = ({ isOpen, onClose, onSave, initialOrder, prefillData }) => {
-  const [formData, setFormData] = useState(initialFormData);
+  const [state, dispatch] = useReducer(orderFormReducer, initialState);
+  const formData = state;
   const [documents, setDocuments] = useState<DocumentFile[]>([]);
   const [internalNotes, setInternalNotes] = useState<InternalNote[]>([]);
   const [currentInternalNote, setCurrentInternalNote] = useState('');
@@ -208,7 +245,7 @@ const OrderForm: React.FC<OrderFormProps> = ({ isOpen, onClose, onSave, initialO
   const [suppliers, setSuppliers] = useState<Supplier[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [currentStep, setCurrentStep] = useState(0);
+  const currentStep = state.currentStep;
 
   const [bfProductValueForSim, setBfProductValueForSim] = useState(0);
   const [bfDownPaymentInput, setBfDownPaymentInput] = useState('R$ 0,00');
@@ -288,7 +325,7 @@ const OrderForm: React.FC<OrderFormProps> = ({ isOpen, onClose, onSave, initialO
             initialBfDownPayment = prefillData.downPayment ?? initialBfDownPayment;
         }
 
-        setFormData(effectiveInitialData);
+        dispatch({ type: 'SET_STATE_FROM_INITIAL', data: { ...effectiveInitialData, currentStep: 0 } });
         setDocuments(effectiveDocuments);
         setInternalNotes(effectiveInternalNotes);
         setBfProductValueForSim(initialBfProductValue);
@@ -314,21 +351,15 @@ const OrderForm: React.FC<OrderFormProps> = ({ isOpen, onClose, onSave, initialO
 
         if (productVal > 0 && formData.installments && formData.installments > 0) {
              const bfDetails = calculateBluFacilitaDetails(productVal, downPaymentVal, formData.installments, annualRateToUse);
-            setFormData(prev => ({ 
-                ...prev, 
-                downPayment: downPaymentVal, 
-                financedAmount: bfDetails.financedAmount, 
-                totalWithInterest: bfDetails.totalWithInterest, 
-                installmentValue: bfDetails.installmentValue 
-            }));
+            dispatch({ type: 'UPDATE_FIELD', field: 'downPayment', value: downPaymentVal });
+            dispatch({ type: 'UPDATE_FIELD', field: 'financedAmount', value: bfDetails.financedAmount });
+            dispatch({ type: 'UPDATE_FIELD', field: 'totalWithInterest', value: bfDetails.totalWithInterest });
+            dispatch({ type: 'UPDATE_FIELD', field: 'installmentValue', value: bfDetails.installmentValue });
         } else {
-             setFormData(prev => ({ 
-                 ...prev, 
-                 downPayment: downPaymentVal, 
-                 financedAmount: Math.max(0, productVal - downPaymentVal), 
-                 totalWithInterest: Math.max(0, productVal - downPaymentVal), 
-                 installmentValue: 0 
-            }));
+             dispatch({ type: 'UPDATE_FIELD', field: 'downPayment', value: downPaymentVal });
+             dispatch({ type: 'UPDATE_FIELD', field: 'financedAmount', value: Math.max(0, productVal - downPaymentVal) });
+             dispatch({ type: 'UPDATE_FIELD', field: 'totalWithInterest', value: Math.max(0, productVal - downPaymentVal) });
+             dispatch({ type: 'UPDATE_FIELD', field: 'installmentValue', value: 0 });
         }
     }
   }, [formData.paymentMethod, formData.sellingPrice, formData.purchasePrice, bfDownPaymentInput, formData.installments, formData.bluFacilitaUsesSpecialRate, formData.bluFacilitaSpecialAnnualRate]);
@@ -338,22 +369,22 @@ const OrderForm: React.FC<OrderFormProps> = ({ isOpen, onClose, onSave, initialO
     const checked = (e.target as HTMLInputElement).checked;
 
     if (name === "bluFacilitaUsesSpecialRate") {
-        setFormData(prev => ({ ...prev, bluFacilitaUsesSpecialRate: checked, bluFacilitaSpecialAnnualRate: checked ? prev.bluFacilitaSpecialAnnualRate : undefined }));
+        dispatch({ type: 'UPDATE_FIELD', field: 'bluFacilitaUsesSpecialRate', value: checked });
+        if (!checked) dispatch({ type: 'UPDATE_FIELD', field: 'bluFacilitaSpecialAnnualRate', value: undefined });
     } else if (["purchasePrice", "sellingPrice", "shippingCostSupplierToBlu", "shippingCostBluToClient", "bluFacilitaSpecialAnnualRate", "batteryHealth"].includes(name)) {
         const numericValue = parseFloat(value);
-        setFormData(prev => ({ ...prev, [name]: isNaN(numericValue) ? undefined : numericValue }));
+        dispatch({ type: 'UPDATE_FIELD', field: name as keyof BaseFormData, value: isNaN(numericValue) ? undefined : numericValue });
         if (name === "sellingPrice" || (name === "purchasePrice" && !formData.sellingPrice)) {
             setBfProductValueForSim(isNaN(numericValue) ? 0 : numericValue);
         }
     } else if (name === "supplierId" || name === "clientId") {
-        setFormData(prev => ({ ...prev, [name]: value || undefined }));
+        dispatch({ type: 'UPDATE_FIELD', field: name as keyof BaseFormData, value: value || undefined });
     } else if (type === 'number' && name === 'installments') {
-        setFormData(prev => ({...prev, [name]: parseInt(value, 10) || 1 }));
+        dispatch({ type: 'UPDATE_FIELD', field: 'installments', value: parseInt(value, 10) || 1 });
     } else if (type === 'checkbox' && name === 'readyForDelivery') {
-        setFormData(prev => ({ ...prev, [name]: checked }));
-    }
-     else {
-      setFormData(prev => ({ ...prev, [name]: value }));
+        dispatch({ type: 'UPDATE_FIELD', field: 'readyForDelivery', value: checked });
+    } else {
+      dispatch({ type: 'UPDATE_FIELD', field: name as keyof BaseFormData, value });
     }
   };
 
@@ -369,7 +400,8 @@ const OrderForm: React.FC<OrderFormProps> = ({ isOpen, onClose, onSave, initialO
     const saved = await saveClient(client);
     const updatedClients = await getClients();
     setClients(updatedClients);
-    setFormData(prev => ({ ...prev, clientId: saved.id, customerNameManual: '' }));
+    dispatch({ type: 'UPDATE_FIELD', field: 'clientId', value: saved.id });
+    dispatch({ type: 'UPDATE_FIELD', field: 'customerNameManual', value: '' });
     setIsClientFormOpen(false);
   };
 
@@ -483,18 +515,7 @@ Observações: O valor desta nota fiscal refere-se exclusivamente ao serviço de
         <Stepper steps={FORM_STEPS} currentStep={currentStep} />
         {currentStep === 0 && (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Card title="Detalhes do Cliente e Produto" className="h-full">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div className="flex items-end space-x-2">
-                        <Select label="Cliente (Existente)" id="clientId" name="clientId" value={formData.clientId || ''} onChange={handleChange} options={[{value: '', label: 'Selecionar cliente...'}, ...clients.map(c => ({ value: c.id, label: c.fullName }))]} placeholder="Ou preencha o nome abaixo" containerClassName="flex-grow" />
-                        <Button type="button" variant="ghost" size="sm" onClick={() => setIsClientFormOpen(true)} title="Novo Cliente"><PlusIcon className="h-5 w-5"/></Button>
-                    </div>
-                    <Input label="Nome do Cliente (Manual/Novo)" id="customerNameManual" name="customerNameManual" value={formData.customerNameManual} onChange={handleChange} disabled={!!formData.clientId} placeholder={formData.clientId ? "Cliente selecionado acima" : "Nome completo do novo cliente"} />
-                </div>
-                 {selectedClientDetails?.isDefaulter && ( <Alert type="warning" message={`Atenção: Cliente ${selectedClientDetails.fullName} está marcado como inadimplente.`} details={selectedClientDetails.defaulterNotes} className="mt-2"/> )}
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4"> <Select label="Produto" id="productName" name="productName" value={formData.productName} onChange={handleChange} options={PRODUCT_OPTIONS.map(p => ({ value: p, label: p }))} /> <Input label="Modelo (ex: 15 Pro Max)" id="model" name="model" value={formData.model} onChange={handleChange} required /> </div>
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4"> <Select label="Armazenamento" id="capacity" name="capacity" value={formData.capacity} onChange={handleChange} options={CAPACITY_OPTIONS.map(c => ({ value: c, label: c }))} /> <Input label="Cor" id="color" name="color" value={formData.color} onChange={handleChange} /> <Select label="Condição" id="condition" name="condition" value={formData.condition} onChange={handleChange} options={PRODUCT_CONDITION_OPTIONS.map(c => ({ value: c, label: c }))} /> </div>
-            </Card>
+            <ClientProductStep state={formData} dispatch={dispatch} />
         </div>)}
 {currentStep === 1 && (
 <>
@@ -544,11 +565,11 @@ Observações: O valor desta nota fiscal refere-se exclusivamente ao serviço de
         </div>
         )}
         <div className="flex justify-between pt-4 border-t mt-6">
-            {currentStep > 0 && <Button type="button" variant="secondary" onClick={() => setCurrentStep(s => s - 1)} disabled={isLoading}>Voltar</Button>}
+            {currentStep > 0 && <Button type="button" variant="secondary" onClick={() => dispatch({ type: 'PREV_STEP' })} disabled={isLoading}>Voltar</Button>}
             <div className="flex space-x-3 ml-auto">
                 <Button type="button" variant="secondary" onClick={onClose} disabled={isLoading}>Cancelar</Button>
                 {currentStep < FORM_STEPS.length - 1 ? (
-                    <Button type="button" onClick={() => setCurrentStep(s => s + 1)} disabled={isLoading}>Próximo</Button>
+                    <Button type="button" onClick={() => dispatch({ type: 'NEXT_STEP' })} disabled={isLoading}>Próximo</Button>
                 ) : (
                     <Button type="submit" isLoading={isLoading} disabled={isLoading}>{initialOrder ? 'Salvar Alterações' : 'Adicionar Encomenda'}</Button>
                 )}

--- a/features/OrdersFeature.tsx
+++ b/features/OrdersFeature.tsx
@@ -17,6 +17,8 @@ import { ClientForm } from './ClientsFeature';
 import { v4 as uuidv4 } from 'uuid';
 import { EyeIcon, EyeSlashIcon, RegisterPaymentModal } from '../App';
 import ClientProductStep from './orders/steps/ClientProductStep';
+import ValuesStep from './orders/steps/ValuesStep';
+import NotesDocsStep from './orders/steps/NotesDocsStep';
 
 
 // Icons
@@ -517,53 +519,36 @@ Observações: O valor desta nota fiscal refere-se exclusivamente ao serviço de
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <ClientProductStep state={formData} dispatch={dispatch} />
         </div>)}
-{currentStep === 1 && (
-<>
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Card title="Valores, Fornecedor e Prazos" className="h-full">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4"> <Select label="Fornecedor" id="supplierId" name="supplierId" value={formData.supplierId || ''} onChange={handleChange} options={supplierOptions} /> {formData.supplierId && suppliers.find(s=>s.id === formData.supplierId)?.phone && ( <Button type="button" variant="ghost" size="sm" onClick={handleWhatsAppConsult} className="mt-6" leftIcon={<WhatsAppIcon className="h-5 w-5 text-green-500" />}> Consultar Fornecedor </Button> )} </div>
-                <Input label="Custo (R$)" id="purchasePrice" name="purchasePrice" type="number" step="0.01" value={String(formData.purchasePrice || '')} onChange={handleChange} required containerClassName="mt-4" />
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4"> <Input label="Valor de Venda (R$) (Opcional)" id="sellingPrice" name="sellingPrice" type="number" step="0.01" value={String(formData.sellingPrice || '')} onChange={handleChange} /> <Select label="Status Inicial" id="status" name="status" value={formData.status} onChange={handleChange} options={ORDER_STATUS_OPTIONS.map(s => ({ value: s, label: s }))} /> <Input label="Data do Pedido" id="orderDate" name="orderDate" type="date" value={formData.orderDate} onChange={handleChange} required /> </div>
-                <Input label="Prazo Estimado de Entrega" id="estimatedDeliveryDate" name="estimatedDeliveryDate" type="date" value={formData.estimatedDeliveryDate || ''} onChange={handleChange} containerClassName="mt-4" />
-                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4"> <Input label="Custo Frete Fornecedor → Blu (R$)" id="shippingCostSupplierToBlu" name="shippingCostSupplierToBlu" type="number" step="0.01" value={String(formData.shippingCostSupplierToBlu || '')} onChange={handleChange} /> <Input label="Custo Frete Blu → Cliente (R$)" id="shippingCostBluToClient" name="shippingCostBluToClient" type="number" step="0.01" value={String(formData.shippingCostBluToClient || '')} onChange={handleChange} /> </div>
-            </Card>
-        </div>
-        <Card title="Forma de Pagamento">
-            <Select label="Forma de Pagamento" id="paymentMethod" name="paymentMethod" value={formData.paymentMethod} onChange={handleChange} options={PAYMENT_METHOD_OPTIONS.map(p => ({value: p, label: p}))} />
-            {formData.paymentMethod === PaymentMethod.BLU_FACILITA && (
-                <div className="mt-4 p-4 border border-blue-200 rounded-md bg-blue-50 space-y-3">
-                    <h4 className="font-semibold text-blue-700">Simulação BluFacilita (Base: {formatCurrencyBRL(bfProductValueForSim)})</h4>
-                     <div className="flex items-center space-x-2"> <input type="checkbox" id="bluFacilitaUsesSpecialRate" name="bluFacilitaUsesSpecialRate" checked={formData.bluFacilitaUsesSpecialRate} onChange={handleChange} className="rounded text-blue-600 focus:ring-blue-500"/> <label htmlFor="bluFacilitaUsesSpecialRate" className="text-sm text-gray-700">Usar Taxa Especial BluFacilita?</label> </div>
-                    {formData.bluFacilitaUsesSpecialRate && ( <Input label="Taxa Anual Especial (%)" id="bluFacilitaSpecialAnnualRate" name="bluFacilitaSpecialAnnualRate" type="number" step="0.01" value={String(formData.bluFacilitaSpecialAnnualRate || '')} onChange={handleChange} placeholder={`Padrão ${DEFAULT_BLU_FACILITA_ANNUAL_INTEREST_RATE * 100}%`} /> )}
-                    <Input label="Entrada (R$)" id="bfDownPaymentInput" name="bfDownPaymentInput" value={bfDownPaymentInput} onChange={handleBfDownPaymentChange} onBlur={handleBfDownPaymentBlur} />
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4"> <Select label="Nº de Parcelas" id="installments" name="installments" value={String(formData.installments || 12)} onChange={handleChange} options={Array.from({length:12}, (_,i)=>({value:i+1, label:`${i+1}x`}))} /> </div>
-                    <p className="text-sm"><strong>Valor Financiado:</strong> {formatCurrencyBRL(formData.financedAmount)}</p>
-                    <p className="text-sm"><strong>Valor da Parcela:</strong> {formatCurrencyBRL(formData.installmentValue)}</p>
-                    <p className="text-sm"><strong>Total com Juros (Financiamento + Entrada):</strong> {formatCurrencyBRL((formData.totalWithInterest || 0) + (formData.downPayment || 0))}</p>
-                    <Select label="Status do Contrato BluFacilita" id="bluFacilitaContractStatus" name="bluFacilitaContractStatus" value={formData.bluFacilitaContractStatus} onChange={handleChange} options={BLU_FACILITA_CONTRACT_STATUS_OPTIONS.map(s => ({value:s, label:s}))} />
-                </div>
-            )}
-        </Card>
-        </>
+        {currentStep === 1 && (
+          <ValuesStep
+            state={formData}
+            suppliers={suppliers}
+            supplierOptions={supplierOptions}
+            bfProductValueForSim={bfProductValueForSim}
+            bfDownPaymentInput={bfDownPaymentInput}
+            handleChange={handleChange}
+            handleWhatsAppConsult={handleWhatsAppConsult}
+            handleBfDownPaymentChange={handleBfDownPaymentChange}
+            handleBfDownPaymentBlur={handleBfDownPaymentBlur}
+          />
         )}
         {currentStep === 2 && (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Card title="Notas e Documentos">
-                <Textarea label="Observações Gerais da Encomenda" id="notes" name="notes" value={formData.notes || ''} onChange={handleChange} rows={3} />
-                <div className="mt-4"> <h4 className="text-sm font-medium text-gray-700 mb-1">Documentos Anexados</h4> {documents.length === 0 && <p className="text-xs text-gray-500">Nenhum documento.</p>} <ul className="list-disc list-inside space-y-1 max-h-24 overflow-y-auto"> {documents.map(doc => ( <li key={doc.id} className="text-sm text-gray-600 flex justify-between items-center"> <span>{doc.name} ({formatDateBR(doc.uploadedAt)})</span> <Button type="button" variant="link" size="sm" onClick={() => handleRemoveDocument(doc.id)} className="text-red-500">Remover</Button> </li> ))} </ul> <Button type="button" variant="ghost" size="sm" onClick={handleAddDocument} className="mt-2"> <i className="heroicons-outline-paper-clip mr-1 h-4 w-4"></i>Adicionar Documento (mock) </Button> </div>
-                <div className="mt-4">
-                    <Button type="button" variant="ghost" size="sm" onClick={generateNotaFiscalDescription} leftIcon={<DocumentTextIcon className="h-4 w-4"/>} className="mt-2">Gerar Descrição p/ Nota Fiscal</Button>
-                </div>
-                <div className="mt-2">
-                    <Button type="button" variant="ghost" size="sm" onClick={generateNotaFiscalProductInfo} leftIcon={<ClipboardDocumentIcon className="h-4 w-4"/>} className="mt-2">Gerar Dados p/ NF Produto</Button>
-                </div>
-            </Card>
-            <Card title="Comunicação e Histórico Interno">
-                 <Textarea label="Resumo do Histórico do WhatsApp (Opcional)" id="whatsAppHistorySummary" name="whatsAppHistorySummary" value={formData.whatsAppHistorySummary || ''} onChange={handleChange} rows={3} placeholder="Ex: Cliente aceitou seminovo se bateria > 85%..." />
-                <div className="mt-4"> <h4 className="text-sm font-medium text-gray-700 mb-1">Notas Internas (Não visível ao cliente)</h4> <div className="max-h-32 overflow-y-auto mb-2 border rounded-md p-2 bg-gray-50 space-y-1"> {internalNotes.length === 0 && <p className="text-xs text-gray-500">Nenhuma nota interna.</p>} {internalNotes.slice().sort((a,b) => new Date(b.date).getTime() - new Date(a.date).getTime()).map(note => ( <div key={note.id} className="text-xs text-gray-600 bg-white p-1.5 rounded shadow-sm"> <div className="flex justify-between items-center"> <span className="font-semibold">{formatDateBR(note.date, true)}</span> <Button type="button" variant="link" size="sm" onClick={() => handleRemoveInternalNote(note.id)} className="text-red-400 hover:text-red-600 p-0 leading-none">X</Button> </div> <p className="whitespace-pre-wrap">{note.note}</p> </div> ))} </div> <div className="flex items-center space-x-2"> <Textarea id="currentInternalNote" value={currentInternalNote} onChange={(e) => setCurrentInternalNote(e.target.value)} rows={2} placeholder="Adicionar nova nota interna..." textareaClassName="text-sm" /> <Button type="button" variant="secondary" size="sm" onClick={handleAddInternalNote} title="Adicionar Nota" className="self-end h-10"> <PlusIcon className="h-4 w-4"/> </Button> </div> </div>
-            </Card>
-        </div>
+          <NotesDocsStep
+            state={formData}
+            documents={documents}
+            internalNotes={internalNotes}
+            currentInternalNote={currentInternalNote}
+            setCurrentInternalNote={setCurrentInternalNote}
+            handleChange={handleChange}
+            handleAddInternalNote={handleAddInternalNote}
+            handleRemoveInternalNote={handleRemoveInternalNote}
+            handleAddDocument={handleAddDocument}
+            handleRemoveDocument={handleRemoveDocument}
+            generateNotaFiscalDescription={generateNotaFiscalDescription}
+            generateNotaFiscalProductInfo={generateNotaFiscalProductInfo}
+          />
         )}
+
         <div className="flex justify-between pt-4 border-t mt-6">
             {currentStep > 0 && <Button type="button" variant="secondary" onClick={() => dispatch({ type: 'PREV_STEP' })} disabled={isLoading}>Voltar</Button>}
             <div className="flex space-x-3 ml-auto">

--- a/features/orders/steps/ClientProductStep.tsx
+++ b/features/orders/steps/ClientProductStep.tsx
@@ -1,7 +1,99 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { Input, Select, Card, Alert } from '../../../components/SharedComponents';
+import { Client, ProductCondition } from '../../../types';
+import { getClients, getClientById, PRODUCT_CONDITION_OPTIONS } from '../../../services/AppService';
+import { OrderFormState, OrderFormAction } from '../../OrdersFeature';
 
-export const ClientProductStep: React.FC = () => {
-  return <div>ClientProductStep</div>;
+const PRODUCT_OPTIONS = ['iPhone', 'MacBook', 'iMac'];
+const CAPACITY_OPTIONS = ['64GB', '128GB', '256GB', '512GB', '1TB'];
+
+interface ComboboxProps {
+  value: string;
+  onChange: (val: string) => void;
+  onSelect: (client: Partial<Client>) => void;
+  results: Client[];
+}
+
+const Combobox: React.FC<ComboboxProps> = ({ value, onChange, onSelect, results }) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="relative">
+      <Input id="clientSearch" value={value} onChange={(e) => { onChange(e.target.value); setOpen(true); }}
+        placeholder="Buscar cliente..." autoComplete="off" />
+      {open && (
+        <ul className="absolute z-10 bg-white border border-gray-300 shadow-md max-h-60 overflow-y-auto w-full">
+          {results.length > 0 ? results.map(c => (
+            <li key={c.id} className="p-2 cursor-pointer hover:bg-gray-100" onMouseDown={() => { onSelect(c); setOpen(false); }}>
+              {c.fullName} {c.cpfOrCnpj && `(${c.cpfOrCnpj})`}
+            </li>
+          )) : value && (
+            <li className="p-2 cursor-pointer hover:bg-gray-100" onMouseDown={() => { onSelect({ fullName: value }); setOpen(false); }}>
+              Adicionar novo cliente: '{value}'
+            </li>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+interface Props {
+  state: OrderFormState;
+  dispatch: React.Dispatch<OrderFormAction>;
+}
+
+export const ClientProductStep: React.FC<Props> = ({ state, dispatch }) => {
+  const [query, setQuery] = useState('');
+  const [options, setOptions] = useState<Client[]>([]);
+  const [selectedClient, setSelectedClient] = useState<Client | null>(null);
+
+  useEffect(() => { setQuery(state.customerNameManual); }, [state.customerNameManual]);
+
+  useEffect(() => {
+    const t = setTimeout(async () => {
+      try { setOptions(await getClients(query)); } catch { setOptions([]); }
+    }, 300);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  useEffect(() => {
+    if (state.clientId) {
+      getClientById(state.clientId).then(c => setSelectedClient(c || null));
+    } else {
+      setSelectedClient(null);
+    }
+  }, [state.clientId]);
+
+  const handleSelect = (client: Partial<Client>) => {
+    dispatch({ type: 'SET_CLIENT', client });
+  };
+
+  return (
+    <Card title="Detalhes do Cliente e Produto" className="h-full">
+      <Combobox value={query} onChange={setQuery} onSelect={handleSelect} results={options} />
+      {selectedClient?.isDefaulter && (
+        <Alert type="warning" message={`Atenção: Cliente ${selectedClient.fullName} está marcado como inadimplente.`}
+               details={selectedClient.defaulterNotes} className="mt-2" />
+      )}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+        <Select label="Produto" id="productName" name="productName" value={state.productName}
+                onChange={(e) => dispatch({ type: 'UPDATE_FIELD', field: 'productName', value: e.target.value })}
+                options={PRODUCT_OPTIONS.map(p => ({ value: p, label: p }))} />
+        <Input label="Modelo (ex: 15 Pro Max)" id="model" name="model" value={state.model}
+               onChange={(e) => dispatch({ type: 'UPDATE_FIELD', field: 'model', value: e.target.value })} required />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
+        <Select label="Armazenamento" id="capacity" name="capacity" value={state.capacity}
+                onChange={(e) => dispatch({ type: 'UPDATE_FIELD', field: 'capacity', value: e.target.value })}
+                options={CAPACITY_OPTIONS.map(c => ({ value: c, label: c }))} />
+        <Input label="Cor" id="color" name="color" value={state.color}
+               onChange={(e) => dispatch({ type: 'UPDATE_FIELD', field: 'color', value: e.target.value })} />
+        <Select label="Condição" id="condition" name="condition" value={state.condition}
+                onChange={(e) => dispatch({ type: 'UPDATE_FIELD', field: 'condition', value: e.target.value as ProductCondition })}
+                options={PRODUCT_CONDITION_OPTIONS.map((c: ProductCondition) => ({ value: c, label: c }))} />
+      </div>
+    </Card>
+  );
 };
 
 export default ClientProductStep;

--- a/features/orders/steps/ClientProductStep.tsx
+++ b/features/orders/steps/ClientProductStep.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const ClientProductStep: React.FC = () => {
+  return <div>ClientProductStep</div>;
+};
+
+export default ClientProductStep;

--- a/features/orders/steps/NotesDocsStep.tsx
+++ b/features/orders/steps/NotesDocsStep.tsx
@@ -1,7 +1,138 @@
 import React from 'react';
+import { Card, Textarea, Button } from '../../../components/SharedComponents';
+import { DocumentFile, InternalNote } from '../../../types';
+import { formatDateBR } from '../../../services/AppService';
+import { OrderFormState } from '../../OrdersFeature';
 
-export const NotesDocsStep: React.FC = () => {
-  return <div>NotesDocsStep</div>;
+interface NotesDocsProps {
+  state: OrderFormState;
+  documents: DocumentFile[];
+  internalNotes: InternalNote[];
+  currentInternalNote: string;
+  setCurrentInternalNote: (val: string) => void;
+  handleChange: (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => void;
+  handleAddInternalNote: () => void;
+  handleRemoveInternalNote: (id: string) => void;
+  handleAddDocument: () => void;
+  handleRemoveDocument: (id: string) => void;
+  generateNotaFiscalDescription: () => void;
+  generateNotaFiscalProductInfo: () => void;
+}
+
+export const NotesDocsStep: React.FC<NotesDocsProps> = ({
+  state,
+  documents,
+  internalNotes,
+  currentInternalNote,
+  setCurrentInternalNote,
+  handleChange,
+  handleAddInternalNote,
+  handleRemoveInternalNote,
+  handleAddDocument,
+  handleRemoveDocument,
+  generateNotaFiscalDescription,
+  generateNotaFiscalProductInfo,
+}) => {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <Card title="Notas e Documentos">
+        <Textarea
+          label="Observações Gerais da Encomenda"
+          id="notes"
+          name="notes"
+          value={state.notes || ''}
+          onChange={handleChange}
+          rows={3}
+        />
+        <div className="mt-4">
+          <h4 className="text-sm font-medium text-gray-700 mb-1">Documentos Anexados</h4>
+          {documents.length === 0 && <p className="text-xs text-gray-500">Nenhum documento.</p>}
+          <ul className="list-disc list-inside space-y-1 max-h-24 overflow-y-auto">
+            {documents.map(doc => (
+              <li key={doc.id} className="text-sm text-gray-600 flex justify-between items-center">
+                <span>
+                  {doc.name} ({formatDateBR(doc.uploadedAt)})
+                </span>
+                <Button type="button" variant="link" size="sm" onClick={() => handleRemoveDocument(doc.id)} className="text-red-500">
+                  Remover
+                </Button>
+              </li>
+            ))}
+          </ul>
+          <Button type="button" variant="ghost" size="sm" onClick={handleAddDocument} className="mt-2">
+            <i className="heroicons-outline-paper-clip mr-1 h-4 w-4"></i>Adicionar Documento (mock)
+          </Button>
+        </div>
+        <div className="mt-4">
+          <Button type="button" variant="ghost" size="sm" onClick={generateNotaFiscalDescription} className="mt-2" leftIcon={<i className="heroicons-outline-document-text h-4 w-4"></i>}>
+            Gerar Descrição p/ Nota Fiscal
+          </Button>
+        </div>
+        <div className="mt-2">
+          <Button type="button" variant="ghost" size="sm" onClick={generateNotaFiscalProductInfo} className="mt-2" leftIcon={<i className="heroicons-outline-clipboard-document h-4 w-4"></i>}>
+            Gerar Dados p/ NF Produto
+          </Button>
+        </div>
+      </Card>
+      <Card title="Comunicação e Histórico Interno">
+        <Textarea
+          label="Resumo do Histórico do WhatsApp (Opcional)"
+          id="whatsAppHistorySummary"
+          name="whatsAppHistorySummary"
+          value={state.whatsAppHistorySummary || ''}
+          onChange={handleChange}
+          rows={3}
+          placeholder="Ex: Cliente aceitou seminovo se bateria > 85%..."
+        />
+        <div className="mt-4">
+          <h4 className="text-sm font-medium text-gray-700 mb-1">Notas Internas (Não visível ao cliente)</h4>
+          <div className="max-h-32 overflow-y-auto mb-2 border rounded-md p-2 bg-gray-50 space-y-1">
+            {internalNotes.length === 0 && <p className="text-xs text-gray-500">Nenhuma nota interna.</p>}
+            {internalNotes
+              .slice()
+              .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+              .map(note => (
+                <div key={note.id} className="text-xs text-gray-600 bg-white p-1.5 rounded shadow-sm">
+                  <div className="flex justify-between items-center">
+                    <span className="font-semibold">{formatDateBR(note.date, true)}</span>
+                    <Button
+                      type="button"
+                      variant="link"
+                      size="sm"
+                      onClick={() => handleRemoveInternalNote(note.id)}
+                      className="text-red-400 hover:text-red-600 p-0 leading-none"
+                    >
+                      X
+                    </Button>
+                  </div>
+                  <p className="whitespace-pre-wrap">{note.note}</p>
+                </div>
+              ))}
+          </div>
+          <div className="flex items-center space-x-2">
+            <Textarea
+              id="currentInternalNote"
+              value={currentInternalNote}
+              onChange={e => setCurrentInternalNote(e.target.value)}
+              rows={2}
+              placeholder="Adicionar nova nota interna..."
+              textareaClassName="text-sm"
+            />
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={handleAddInternalNote}
+              title="Adicionar Nota"
+              className="self-end h-10"
+            >
+              <i className="heroicons-outline-plus h-4 w-4"></i>
+            </Button>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
 };
 
 export default NotesDocsStep;

--- a/features/orders/steps/NotesDocsStep.tsx
+++ b/features/orders/steps/NotesDocsStep.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const NotesDocsStep: React.FC = () => {
+  return <div>NotesDocsStep</div>;
+};
+
+export default NotesDocsStep;

--- a/features/orders/steps/ValuesStep.tsx
+++ b/features/orders/steps/ValuesStep.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const ValuesStep: React.FC = () => {
+  return <div>ValuesStep</div>;
+};
+
+export default ValuesStep;

--- a/features/orders/steps/ValuesStep.tsx
+++ b/features/orders/steps/ValuesStep.tsx
@@ -1,7 +1,208 @@
 import React from 'react';
+import { Input, Select, Card, Button, WhatsAppIcon } from '../../../components/SharedComponents';
+import { PaymentMethod, PAYMENT_METHOD_OPTIONS, BLU_FACILITA_CONTRACT_STATUS_OPTIONS, DEFAULT_BLU_FACILITA_ANNUAL_INTEREST_RATE, Supplier, SupplierOption } from '../../../types';
+import { ORDER_STATUS_OPTIONS, formatCurrencyBRL } from '../../../services/AppService';
+import { OrderFormState } from '../../OrdersFeature';
 
-export const ValuesStep: React.FC = () => {
-  return <div>ValuesStep</div>;
+interface ValuesStepProps {
+  state: OrderFormState;
+  suppliers: Supplier[];
+  supplierOptions: SupplierOption[];
+  bfProductValueForSim: number;
+  bfDownPaymentInput: string;
+  handleChange: (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => void;
+  handleWhatsAppConsult: () => void;
+  handleBfDownPaymentChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleBfDownPaymentBlur: () => void;
+}
+
+export const ValuesStep: React.FC<ValuesStepProps> = ({
+  state,
+  suppliers,
+  supplierOptions,
+  bfProductValueForSim,
+  bfDownPaymentInput,
+  handleChange,
+  handleWhatsAppConsult,
+  handleBfDownPaymentChange,
+  handleBfDownPaymentBlur,
+}) => {
+  return (
+    <>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card title="Valores, Fornecedor e Prazos" className="h-full">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <Select
+              label="Fornecedor"
+              id="supplierId"
+              name="supplierId"
+              value={state.supplierId || ''}
+              onChange={handleChange}
+              options={supplierOptions}
+            />
+            {state.supplierId && suppliers.find(s => s.id === state.supplierId)?.phone && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={handleWhatsAppConsult}
+                className="mt-6"
+                leftIcon={<WhatsAppIcon className="h-5 w-5 text-green-500" />}
+              >
+                Consultar Fornecedor
+              </Button>
+            )}
+          </div>
+          <Input
+            label="Custo (R$)"
+            id="purchasePrice"
+            name="purchasePrice"
+            type="number"
+            step="0.01"
+            value={String(state.purchasePrice || '')}
+            onChange={handleChange}
+            required
+            containerClassName="mt-4"
+          />
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
+            <Input
+              label="Valor de Venda (R$) (Opcional)"
+              id="sellingPrice"
+              name="sellingPrice"
+              type="number"
+              step="0.01"
+              value={String(state.sellingPrice || '')}
+              onChange={handleChange}
+            />
+            <Select
+              label="Status Inicial"
+              id="status"
+              name="status"
+              value={state.status}
+              onChange={handleChange}
+              options={ORDER_STATUS_OPTIONS.map(s => ({ value: s, label: s }))}
+            />
+            <Input
+              label="Data do Pedido"
+              id="orderDate"
+              name="orderDate"
+              type="date"
+              value={state.orderDate}
+              onChange={handleChange}
+              required
+            />
+          </div>
+          <Input
+            label="Prazo Estimado de Entrega"
+            id="estimatedDeliveryDate"
+            name="estimatedDeliveryDate"
+            type="date"
+            value={state.estimatedDeliveryDate || ''}
+            onChange={handleChange}
+            containerClassName="mt-4"
+          />
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+            <Input
+              label="Custo Frete Fornecedor → Blu (R$)"
+              id="shippingCostSupplierToBlu"
+              name="shippingCostSupplierToBlu"
+              type="number"
+              step="0.01"
+              value={String(state.shippingCostSupplierToBlu || '')}
+              onChange={handleChange}
+            />
+            <Input
+              label="Custo Frete Blu → Cliente (R$)"
+              id="shippingCostBluToClient"
+              name="shippingCostBluToClient"
+              type="number"
+              step="0.01"
+              value={String(state.shippingCostBluToClient || '')}
+              onChange={handleChange}
+            />
+          </div>
+        </Card>
+      </div>
+      <Card title="Forma de Pagamento">
+        <Select
+          label="Forma de Pagamento"
+          id="paymentMethod"
+          name="paymentMethod"
+          value={state.paymentMethod}
+          onChange={handleChange}
+          options={PAYMENT_METHOD_OPTIONS.map(p => ({ value: p, label: p }))}
+        />
+        {state.paymentMethod === PaymentMethod.BLU_FACILITA && (
+          <div className="mt-4 p-4 border border-blue-200 rounded-md bg-blue-50 space-y-3">
+            <h4 className="font-semibold text-blue-700">
+              Simulação BluFacilita (Base: {formatCurrencyBRL(bfProductValueForSim)})
+            </h4>
+            <div className="flex items-center space-x-2">
+              <input
+                type="checkbox"
+                id="bluFacilitaUsesSpecialRate"
+                name="bluFacilitaUsesSpecialRate"
+                checked={state.bluFacilitaUsesSpecialRate}
+                onChange={handleChange}
+                className="rounded text-blue-600 focus:ring-blue-500"
+              />
+              <label htmlFor="bluFacilitaUsesSpecialRate" className="text-sm text-gray-700">
+                Usar Taxa Especial BluFacilita?
+              </label>
+            </div>
+            {state.bluFacilitaUsesSpecialRate && (
+              <Input
+                label="Taxa Anual Especial (%)"
+                id="bluFacilitaSpecialAnnualRate"
+                name="bluFacilitaSpecialAnnualRate"
+                type="number"
+                step="0.01"
+                value={String(state.bluFacilitaSpecialAnnualRate || '')}
+                onChange={handleChange}
+                placeholder={`Padrão ${DEFAULT_BLU_FACILITA_ANNUAL_INTEREST_RATE * 100}%`}
+              />
+            )}
+            <Input
+              label="Entrada (R$)"
+              id="bfDownPaymentInput"
+              name="bfDownPaymentInput"
+              value={bfDownPaymentInput}
+              onChange={handleBfDownPaymentChange}
+              onBlur={handleBfDownPaymentBlur}
+            />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <Select
+                label="Nº de Parcelas"
+                id="installments"
+                name="installments"
+                value={String(state.installments || 12)}
+                onChange={handleChange}
+                options={Array.from({ length: 12 }, (_, i) => ({ value: i + 1, label: `${i + 1}x` }))}
+              />
+            </div>
+            <p className="text-sm">
+              <strong>Valor Financiado:</strong> {formatCurrencyBRL(state.financedAmount)}
+            </p>
+            <p className="text-sm">
+              <strong>Valor da Parcela:</strong> {formatCurrencyBRL(state.installmentValue)}
+            </p>
+            <p className="text-sm">
+              <strong>Total com Juros (Financiamento + Entrada):</strong>{' '}
+              {formatCurrencyBRL((state.totalWithInterest || 0) + (state.downPayment || 0))}
+            </p>
+            <Select
+              label="Status do Contrato BluFacilita"
+              id="bluFacilitaContractStatus"
+              name="bluFacilitaContractStatus"
+              value={state.bluFacilitaContractStatus}
+              onChange={handleChange}
+              options={BLU_FACILITA_CONTRACT_STATUS_OPTIONS.map(s => ({ value: s, label: s }))}
+            />
+          </div>
+        )}
+      </Card>
+    </>
+  );
 };
 
 export default ValuesStep;

--- a/server/server.js
+++ b/server/server.js
@@ -321,8 +321,18 @@ const CLIENTS_SELECT_QUERY = `
 `;
 
 app.get('/api/clients', authenticateToken, (req, res) => {
-    const query = `${CLIENTS_SELECT_QUERY} WHERE "userId" = $1 ORDER BY "fullName" ASC`;
-    db.all(query, [req.user.id], (err, rows) => {
+    const search = req.query.search ? String(req.query.search) : null;
+    let query = `${CLIENTS_SELECT_QUERY} WHERE "userId" = $1`;
+    const params = [req.user.id];
+
+    if (search) {
+        query += ` AND ("fullName" LIKE $2 OR "cpfOrCnpj" LIKE $2)`;
+        params.push(`%${search}%`);
+    }
+
+    query += ' ORDER BY "fullName" ASC';
+
+    db.all(query, params, (err, rows) => {
       if (err) {
         console.error("Error fetching clients:", err.message);
         return res.status(500).json({ message: 'Failed to fetch clients.' });

--- a/services/AppService.tsx
+++ b/services/AppService.tsx
@@ -297,8 +297,9 @@ export const deleteOrder = async (orderId: string): Promise<void> => {
 };
 
 // --- Client Service ---
-export const getClients = async (): Promise<Client[]> => {
-    return apiClient<Client[]>('/clients');
+export const getClients = async (search?: string): Promise<Client[]> => {
+    const url = search ? `/clients?search=${encodeURIComponent(search)}` : '/clients';
+    return apiClient<Client[]>(url);
 };
 export const saveClient = async (clientData: Omit<Client, 'id'|'userId'> | Client): Promise<Client> => {
     const clientToSave = { ...clientData, registrationDate: clientData.registrationDate || new Date().toISOString() };


### PR DESCRIPTION
## Summary
- add optional search filtering for `GET /api/clients`
- scaffold order form step components in `features/orders/steps`

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6847534e8e44832296ec2214394b7741