### PR TITLE
Atualiza campos do passo de cliente

### DIFF
--- a/features/OrdersFeature.tsx
+++ b/features/OrdersFeature.tsx
@@ -380,6 +380,9 @@ const OrderForm: React.FC<OrderFormProps> = ({ isOpen, onClose, onSave, initialO
     if (name === "bluFacilitaUsesSpecialRate") {
         dispatch({ type: 'UPDATE_FIELD', field: 'bluFacilitaUsesSpecialRate', value: checked });
         if (!checked) dispatch({ type: 'UPDATE_FIELD', field: 'bluFacilitaSpecialAnnualRate', value: undefined });
+    } else if (name === 'productName') {
+        dispatch({ type: 'UPDATE_FIELD', field: 'productName', value });
+        dispatch({ type: 'UPDATE_FIELD', field: 'model', value: '' });
     } else if (["purchasePrice", "sellingPrice", "shippingCostSupplierToBlu", "shippingCostBluToClient", "bluFacilitaSpecialAnnualRate", "batteryHealth"].includes(name)) {
         const numericValue = parseFloat(value);
         dispatch({ type: 'UPDATE_FIELD', field: name as keyof BaseFormData, value: isNaN(numericValue) ? undefined : numericValue });

--- a/features/orders/steps/ClientProductStep.tsx
+++ b/features/orders/steps/ClientProductStep.tsx
@@ -4,7 +4,14 @@ import { Client, ProductCondition } from '../../../types';
 import { getClients, getClientById, PRODUCT_CONDITION_OPTIONS } from '../../../services/AppService';
 import { OrderFormState, OrderFormAction } from '../../OrdersFeature';
 
-const PRODUCT_OPTIONS = ['iPhone', 'MacBook', 'iMac'];
+const PRODUCT_OPTIONS = ['iPhone', 'MacBook', 'iPad', 'Apple Watch', 'Mac Mini'];
+const PRODUCT_MODELS: { [key: string]: string[] } = {
+  'iPhone': ['15 Pro Max', '15 Pro', '15 Plus', '15', '14 Pro Max', '14 Pro', '14 Plus', '14', 'SE (3ª ger)', '13 Pro Max', '13 Pro', '13', '13 Mini', '12 Pro Max', '12 Pro', '12', '12 Mini', 'SE (2ª ger)'],
+  'MacBook': ['Air 15" (M3)', 'Air 13" (M3)', 'Pro 14" (M3)', 'Pro 14" (M3 Pro/Max)', 'Pro 16" (M3 Pro/Max)', 'Air 15" (M2)', 'Pro 13" (M2)', 'Air (M2)', 'Pro 14" (M2 Pro/Max)', 'Pro 16" (M2 Pro/Max)', 'Air (M1)', 'Pro 13" (M1)'],
+  'iPad': ['Pro 13" (M4)', 'Pro 11" (M4)', 'Air 13" (M2)', 'Air 11" (M2)', 'iPad (10ª ger)', 'Pro 12.9" (M2)', 'Pro 11" (M2)', 'Air (M1 - 5ª ger)', 'Mini (6ª ger)', 'iPad (9ª ger)', 'Pro 12.9" (M1)', 'Pro 11" (M1)'],
+  'Apple Watch': ['Series 9', 'Ultra 2', 'SE (2ª ger)', 'Series 8', 'Ultra', 'Series 7', 'SE (1ª ger)', 'Series 6'],
+  'Mac Mini': ['Mac Mini (M2)', 'Mac Mini (M2 Pro)', 'Mac Mini (M1)'],
+};
 const CAPACITY_OPTIONS = ['64GB', '128GB', '256GB', '512GB', '1TB'];
 
 interface ComboboxProps {
@@ -76,21 +83,50 @@ export const ClientProductStep: React.FC<Props> = ({ state, dispatch }) => {
                details={selectedClient.defaulterNotes} className="mt-2" />
       )}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
-        <Select label="Produto" id="productName" name="productName" value={state.productName}
-                onChange={(e) => dispatch({ type: 'UPDATE_FIELD', field: 'productName', value: e.target.value })}
-                options={PRODUCT_OPTIONS.map(p => ({ value: p, label: p }))} />
-        <Input label="Modelo (ex: 15 Pro Max)" id="model" name="model" value={state.model}
-               onChange={(e) => dispatch({ type: 'UPDATE_FIELD', field: 'model', value: e.target.value })} required />
-      </div>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
-        <Select label="Armazenamento" id="capacity" name="capacity" value={state.capacity}
-                onChange={(e) => dispatch({ type: 'UPDATE_FIELD', field: 'capacity', value: e.target.value })}
-                options={CAPACITY_OPTIONS.map(c => ({ value: c, label: c }))} />
-        <Input label="Cor" id="color" name="color" value={state.color}
-               onChange={(e) => dispatch({ type: 'UPDATE_FIELD', field: 'color', value: e.target.value })} />
-        <Select label="Condição" id="condition" name="condition" value={state.condition}
-                onChange={(e) => dispatch({ type: 'UPDATE_FIELD', field: 'condition', value: e.target.value as ProductCondition })}
-                options={PRODUCT_CONDITION_OPTIONS.map((c: ProductCondition) => ({ value: c, label: c }))} />
+        <Select
+          label="Produto"
+          id="productName"
+          name="productName"
+          value={state.productName}
+          onChange={(e) => dispatch({ type: 'UPDATE_FIELD', field: 'productName', value: e.target.value })}
+          options={PRODUCT_OPTIONS.map(p => ({ value: p, label: p }))}
+        />
+        <Select
+          label="Modelo"
+          id="model"
+          name="model"
+          value={state.model}
+          onChange={(e) => dispatch({ type: 'UPDATE_FIELD', field: 'model', value: e.target.value })}
+          disabled={!state.productName}
+          options={
+            state.productName
+              ? PRODUCT_MODELS[state.productName].map(m => ({ value: m, label: m }))
+              : [{ value: '', label: 'Selecione um produto...' }]
+          }
+        />
+        <Select
+          label="Armazenamento"
+          id="capacity"
+          name="capacity"
+          value={state.capacity}
+          onChange={(e) => dispatch({ type: 'UPDATE_FIELD', field: 'capacity', value: e.target.value })}
+          options={CAPACITY_OPTIONS.map(c => ({ value: c, label: c }))}
+        />
+        <Input
+          label="Cor"
+          id="color"
+          name="color"
+          value={state.color}
+          onChange={(e) => dispatch({ type: 'UPDATE_FIELD', field: 'color', value: e.target.value })}
+        />
+        <Select
+          label="Condição"
+          id="condition"
+          name="condition"
+          value={state.condition}
+          onChange={(e) => dispatch({ type: 'UPDATE_FIELD', field: 'condition', value: e.target.value as ProductCondition })}
+          options={PRODUCT_CONDITION_OPTIONS.map((c: ProductCondition) => ({ value: c, label: c }))}
+        />
       </div>
     </Card>
   );


### PR DESCRIPTION
## Summary
- atualiza constantes de produtos e modelos
- unifica grid de campos do produto
- converte campo de modelo para select

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68475d7487dc8322b29bb6369161fe68