### PR TITLE
Fix client form null merge

### DIFF
--- a/features/ClientsFeature.tsx
+++ b/features/ClientsFeature.tsx
@@ -69,12 +69,16 @@ const ClientForm: React.FC<ClientFormProps> = ({ isOpen, onClose, onSave, initia
   
   useEffect(() => {
     if (initialClient) {
-      // Merge with initialFormData to ensure optional fields exist
+      // Merge with initialFormData and sanitize nullish values
       setFormData({
         ...initialFormData,
         ...initialClient,
-        notes: initialClient.notes || '',
-        defaulterNotes: initialClient.defaulterNotes || '',
+        address: initialClient.address ?? '',
+        cep: initialClient.cep ?? '',
+        city: initialClient.city ?? '',
+        state: initialClient.state ?? '',
+        notes: initialClient.notes ?? '',
+        defaulterNotes: initialClient.defaulterNotes ?? '',
       });
     } else {
       setFormData(initialFormData);


### PR DESCRIPTION
## Summary
- sanitize fields when editing a client to avoid null errors

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6847602891ec83229a815a27ae444d01