### PR TITLE
Add order progress bar

### DIFF
--- a/components/SharedComponents.tsx
+++ b/components/SharedComponents.tsx
@@ -1,5 +1,6 @@
 
 import React, { ReactNode, useState, useEffect } from 'react';
+import { OrderStatus } from '../types';
 
 // --- Simple Error Boundary to avoid blank pages on runtime errors ---
 interface ErrorBoundaryProps { children: ReactNode; }
@@ -485,6 +486,48 @@ export const Stepper: React.FC<StepperProps> = ({ steps, currentStep }) => (
     ))}
   </div>
 );
+
+interface OrderProgressBarProps {
+  status: OrderStatus;
+}
+
+const ORDER_PROGRESS_STEPS = [
+  { label: 'Contrato assinado', statuses: [OrderStatus.PEDIDO_CRIADO] },
+  { label: 'Pagamento recebido', statuses: [OrderStatus.PAGAMENTO_CONFIRMADO] },
+  { label: 'Produto comprado', statuses: [OrderStatus.COMPRA_REALIZADA] },
+  { label: 'Em trânsito', statuses: [
+      OrderStatus.A_CAMINHO_DO_ESCRITORIO,
+      OrderStatus.CHEGOU_NO_ESCRITORIO,
+      OrderStatus.AGUARDANDO_RETIRADA,
+      OrderStatus.ENVIADO,
+    ] },
+  { label: 'Entregue', statuses: [OrderStatus.ENTREGUE] },
+];
+
+const getProgressIndex = (status: OrderStatus): number => {
+  for (let i = ORDER_PROGRESS_STEPS.length - 1; i >= 0; i--) {
+    if (ORDER_PROGRESS_STEPS[i].statuses.includes(status)) return i;
+  }
+  return 0;
+};
+
+export const OrderProgressBar: React.FC<OrderProgressBarProps> = ({ status }) => {
+  const currentIdx = getProgressIndex(status);
+  return (
+    <div className="flex items-center space-x-1 w-full" title={ORDER_PROGRESS_STEPS[currentIdx].label}>
+      {ORDER_PROGRESS_STEPS.map((_, idx) => (
+        <React.Fragment key={idx}>
+          <div
+            className={`w-2 h-2 rounded-full ${idx <= currentIdx ? 'bg-blu-primary' : 'bg-gray-300'}`}
+          />
+          {idx < ORDER_PROGRESS_STEPS.length - 1 && (
+            <div className={`flex-1 h-0.5 ${idx < currentIdx ? 'bg-blu-primary' : 'bg-gray-300'}`} />
+          )}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+};
 
 interface ToastProps {
   message: string;

--- a/features/OrdersFeature.tsx
+++ b/features/OrdersFeature.tsx
@@ -13,7 +13,7 @@ import {
   getClientPaymentsByOrderId,
   sendOrderContractToAutentique,
 } from '../services/AppService';
-import { Button, Modal, Input, Select, Textarea, Card, PageTitle, Alert, ResponsiveTable, Spinner, WhatsAppIcon, ClipboardDocumentIcon, Stepper, Toast } from '../components/SharedComponents';
+import { Button, Modal, Input, Select, Textarea, Card, PageTitle, Alert, ResponsiveTable, Spinner, WhatsAppIcon, ClipboardDocumentIcon, Stepper, Toast, OrderProgressBar } from '../components/SharedComponents';
 import { ClientForm } from './ClientsFeature';
 import { v4 as uuidv4 } from 'uuid';
 import { EyeIcon, EyeSlashIcon, RegisterPaymentModal } from '../App';
@@ -784,7 +784,12 @@ export const OrdersPage = () => {
           '(Atraso)'}
       </span>
     )},
-    { header: 'Pagamento', accessor: 'paymentMethod' as keyof Order}, 
+    { header: 'Progresso', accessor: (item: Order): ReactNode => (
+        <div className="w-32">
+          <OrderProgressBar status={item.status} />
+        </div>
+    )},
+    { header: 'Pagamento', accessor: 'paymentMethod' as keyof Order},
     { header: 'Prazo/Chegada', accessor: (item: Order): ReactNode => item.arrivalDate ? <span className="text-gray-700">Chegou: {formatDateBR(item.arrivalDate)}</span> : <CountdownDisplay targetDate={item.estimatedDeliveryDate} /> }, 
     { header: 'Ações', accessor: (item: Order): ReactNode => (
         <div className="flex flex-wrap items-center space-x-1">


### PR DESCRIPTION
## Summary
- implement `OrderProgressBar` component for a quick visual of order stage
- display progress bar column in orders table

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6847847f2e0883229f8677382a7fb2cb