### PR TITLE
Add monthly reminders widget

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -12,7 +12,8 @@ import { CardFeeCalculatorPage } from './features/CardFeeCalculatorFeature';
 import { TradeInEvaluationPage } from './features/TradeInEvaluationFeature';
 import { FinancialReportsPageContainer } from './features/FinancialReportsFeature';
 import { UserManagementPage } from './features/UserManagementFeature';
-import { PageTitle, Card, Tabs, Tab, ResponsiveTable, Spinner, Button, Modal, Select as SharedSelect, Alert, Input as SharedInput, Textarea as SharedTextarea } from './components/SharedComponents'; 
+import { PageTitle, Card, Tabs, Tab, ResponsiveTable, Spinner, Button, Modal, Select as SharedSelect, Alert, Input as SharedInput, Textarea as SharedTextarea } from './components/SharedComponents';
+import RemindersWidget from './components/RemindersWidget';
 import { 
     APP_NAME, 
     getDashboardStatistics, formatCurrencyBRL, getTodaysTasks, formatDateBR, getOrderById, 
@@ -279,6 +280,7 @@ const DashboardHomePage: React.FC<{}> = () => {
     
     return ( <div> <PageTitle title="Painel Principal" subtitle={`Bem-vindo, ${currentUser?.email || 'Usuário'}!`} actions={<Button onClick={() => setIsAddCostModalOpen(true)} leftIcon={<PlusCircleIcon className="h-5 w-5"/>}>Registrar Custo</Button>} /> 
         <DolarHojeWidget />
+        <RemindersWidget />
         <Tabs className="mb-6"> <Tab label="Visão Geral" isActive={activeTab === 'overview'} onClick={() => setActiveTab('overview')} /> <Tab label="Para Hoje" isActive={activeTab === 'today'} onClick={() => setActiveTab('today')} /> </Tabs>
         {activeTab === 'overview' && (
             <>

--- a/components/RemindersWidget.tsx
+++ b/components/RemindersWidget.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import { Card } from './SharedComponents';
+
+interface Reminder {
+  id: string;
+  text: string;
+}
+
+const REMINDERS: Reminder[] = [
+  { id: 'export-invoices-monthly', text: 'Todo final de mês exportar notas fiscais do mês para a contabilidade.' }
+];
+
+export const RemindersWidget: React.FC = () => {
+  const [status, setStatus] = useState<Record<string, boolean>>(() => {
+    const stored = localStorage.getItem('reminderStatus');
+    return stored ? JSON.parse(stored) : {};
+  });
+
+  useEffect(() => {
+    localStorage.setItem('reminderStatus', JSON.stringify(status));
+  }, [status]);
+
+  const toggle = (id: string) => {
+    setStatus(prev => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  return (
+    <Card title="Lembretes" className="mb-6">
+      <ul className="space-y-2">
+        {REMINDERS.map(rem => (
+          <li key={rem.id} className="flex items-start">
+            <input
+              id={rem.id}
+              type="checkbox"
+              checked={!!status[rem.id]}
+              onChange={() => toggle(rem.id)}
+              className="mt-1 mr-2 h-4 w-4 text-blu-primary border-gray-300 rounded"
+            />
+            <label htmlFor={rem.id} className="text-sm text-gray-800">
+              {rem.text}
+            </label>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+};
+
+export default RemindersWidget;


### PR DESCRIPTION
## Summary
- add new `RemindersWidget` component with persistent checkboxes
- show reminders widget on the homepage

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684786f53ef48322a1297dfc828f55ef