### PR TITLE
Add pending orders widget

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,6 +14,7 @@ import { FinancialReportsPageContainer } from './features/FinancialReportsFeatur
 import { UserManagementPage } from './features/UserManagementFeature';
 import { PageTitle, Card, Tabs, Tab, ResponsiveTable, Spinner, Button, Modal, Select as SharedSelect, Alert, Input as SharedInput, Textarea as SharedTextarea } from './components/SharedComponents';
 import RemindersWidget from './components/RemindersWidget';
+import PendingOrdersWidget from './components/PendingOrdersWidget';
 import { 
     APP_NAME, 
     getDashboardStatistics, formatCurrencyBRL, getTodaysTasks, formatDateBR, getOrderById, 
@@ -281,6 +282,7 @@ const DashboardHomePage: React.FC<{}> = () => {
     return ( <div> <PageTitle title="Painel Principal" subtitle={`Bem-vindo, ${currentUser?.email || 'Usuário'}!`} actions={<Button onClick={() => setIsAddCostModalOpen(true)} leftIcon={<PlusCircleIcon className="h-5 w-5"/>}>Registrar Custo</Button>} /> 
         <DolarHojeWidget />
         <RemindersWidget />
+        <PendingOrdersWidget />
         <Tabs className="mb-6"> <Tab label="Visão Geral" isActive={activeTab === 'overview'} onClick={() => setActiveTab('overview')} /> <Tab label="Para Hoje" isActive={activeTab === 'today'} onClick={() => setActiveTab('today')} /> </Tabs>
         {activeTab === 'overview' && (
             <>

--- a/components/PendingOrdersWidget.tsx
+++ b/components/PendingOrdersWidget.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getOrders, formatDateBR } from '../services/AppService';
+import { Order, OrderStatus } from '../types';
+import { Card, Button, Spinner } from './SharedComponents';
+
+const ACTION_STATUSES: OrderStatus[] = [
+  OrderStatus.AGUARDANDO_PAGAMENTO_FORNECEDOR,
+  OrderStatus.AGUARDANDO_EMBALAR,
+  OrderStatus.AGUARDANDO_GERAR_NF,
+];
+
+const PendingOrdersWidget: React.FC = () => {
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetch = async () => {
+      try {
+        const all = await getOrders();
+        setOrders(all.filter(o => ACTION_STATUSES.includes(o.status as OrderStatus)));
+      } catch (e) {
+        console.error('Falha ao carregar pedidos pendentes', e);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetch();
+  }, []);
+
+  if (loading) {
+    return (
+      <Card title="Pedidos aguardando ação" className="mb-6 flex justify-center p-4">
+        <Spinner />
+      </Card>
+    );
+  }
+
+  if (orders.length === 0) {
+    return (
+      <Card title="Pedidos aguardando ação" className="mb-6">
+        <p className="p-4 text-center text-gray-500">Nenhum pedido pendente.</p>
+      </Card>
+    );
+  }
+
+  const viewOrder = (id: string) => {
+    navigate(`/orders?viewOrderId=${id}`);
+  };
+
+  return (
+    <Card title="Pedidos aguardando ação" className="mb-6">
+      <ul className="divide-y divide-gray-200">
+        {orders.map(o => (
+          <li key={o.id} className="flex items-center justify-between py-2">
+            <div>
+              <p className="font-semibold text-gray-800">{o.productName} {o.model}</p>
+              <p className="text-sm text-gray-600">
+                {o.customerName} - {formatDateBR(o.orderDate)}
+              </p>
+              <span className="text-xs text-yellow-700 font-semibold">{o.status}</span>
+            </div>
+            <Button variant="link" size="sm" onClick={() => viewOrder(o.id)}>
+              Ver
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+};
+
+export default PendingOrdersWidget;

--- a/components/SharedComponents.tsx
+++ b/components/SharedComponents.tsx
@@ -494,10 +494,15 @@ interface OrderProgressBarProps {
 const ORDER_PROGRESS_STEPS = [
   { label: 'Contrato assinado', statuses: [OrderStatus.PEDIDO_CRIADO] },
   { label: 'Pagamento recebido', statuses: [OrderStatus.PAGAMENTO_CONFIRMADO] },
-  { label: 'Produto comprado', statuses: [OrderStatus.COMPRA_REALIZADA] },
+  { label: 'Produto comprado', statuses: [
+      OrderStatus.AGUARDANDO_PAGAMENTO_FORNECEDOR,
+      OrderStatus.COMPRA_REALIZADA,
+    ] },
   { label: 'Em trânsito', statuses: [
       OrderStatus.A_CAMINHO_DO_ESCRITORIO,
       OrderStatus.CHEGOU_NO_ESCRITORIO,
+      OrderStatus.AGUARDANDO_EMBALAR,
+      OrderStatus.AGUARDANDO_GERAR_NF,
       OrderStatus.AGUARDANDO_RETIRADA,
       OrderStatus.ENVIADO,
     ] },

--- a/types.ts
+++ b/types.ts
@@ -1,9 +1,12 @@
 export enum OrderStatus {
   PEDIDO_CRIADO = 'Pedido Criado',
   PAGAMENTO_CONFIRMADO = 'Pagamento Confirmado',
+  AGUARDANDO_PAGAMENTO_FORNECEDOR = 'Aguardando Pagar Fornecedor',
   COMPRA_REALIZADA = 'Compra Realizada',
   A_CAMINHO_DO_ESCRITORIO = 'A Caminho do Escritório',
   CHEGOU_NO_ESCRITORIO = 'Chegou no Escritório',
+  AGUARDANDO_EMBALAR = 'Aguardando Embalar',
+  AGUARDANDO_GERAR_NF = 'Aguardando Gerar NF',
   AGUARDANDO_RETIRADA = 'Aguardando Retirada',
   ENVIADO = 'Enviado',
   ENTREGUE = 'Entregue',


### PR DESCRIPTION
## Summary
- add new order statuses for waiting on supplier payment, packing, and invoicing
- update order progress bar for new statuses
- display pending orders on the dashboard

## Testing
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684788512a948322a70dfbd1ac0e8625