### PR TITLE
Fix Gemini parse error

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -842,7 +842,7 @@ app.post('/api/gemini/parse-supplier-list', authenticateToken, async (req, res) 
       ` produto, modelo, capacidade, condicao, cor, pais, precoBRL.\n` +
       `Lista do fornecedor ${supplierName}:\n${textList}`;
     const result = await model.generateContent(prompt);
-    let text = result.response.text();
+    let text = result.response.text;
     try {
       const json = JSON.parse(text.trim());
       res.json(json);


### PR DESCRIPTION
## Summary
- fix use of response.text from Google GenAI SDK so Gemini parsing works

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68480966aa7083228f6cab26c2748e13