### PR TITLE
Improve error message for Gemini list parsing

### DIFF
--- a/services/AppService.tsx
+++ b/services/AppService.tsx
@@ -202,6 +202,9 @@ export const parseSupplierListWithGemini = async ( textList: string, supplier: S
     return [];
   } catch (error) {
     console.error("Error calling backend for Gemini parsing:", error);
+    if (error instanceof Error) {
+      throw new Error(`Falha ao comunicar com o servidor para processar a lista: ${error.message}`);
+    }
     throw new Error("Falha ao comunicar com o servidor para processar a lista. Verifique o console para detalhes.");
   }
 };


### PR DESCRIPTION
## Summary
- surface backend error messages when parsing supplier lists so they are visible in the UI

## Testing
- `npm run build`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68481f49ade88322823d88570802209c