### PR TITLE
Fix Gemini parsing call

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -878,7 +878,10 @@ app.post('/api/gemini/parse-supplier-list', authenticateToken, async (req, res) 
 
     const result = await model.generateContent(prompt);
     const response = await result.response;
-    const jsonText = response.text().replace(/^```json\n/, '').replace(/\n```$/, '');
+    const rawText = await response.text();
+    const jsonText = rawText
+      .replace(/^```json\n/, '')
+      .replace(/\n```$/, '');
 
     const parsedData = JSON.parse(jsonText);
     res.json(parsedData);


### PR DESCRIPTION
## Summary
- fix asynchronous handling of Gemini response text in `server.js`

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6848211fb4fc832298ef724363a25836