### PR TITLE
Improve supplier price parsing

### DIFF
--- a/features/MarketAnalysisFeature.tsx
+++ b/features/MarketAnalysisFeature.tsx
@@ -69,6 +69,9 @@ export const MarketAnalysisPage: React.FC<{}> = () => {
   const aggregatedColumns = useMemo(() => [
     { header: 'Produto', accessor: (i: AggregatedProductPrice): ReactNode => `${i.productName} ${i.model}` },
     { header: 'Capacidade', accessor: 'capacity' as keyof AggregatedProductPrice },
+    { header: 'Cor', accessor: 'color' as keyof AggregatedProductPrice },
+    { header: 'Características', accessor: 'characteristics' as keyof AggregatedProductPrice },
+    { header: 'País', accessor: 'country' as keyof AggregatedProductPrice },
     { header: 'Condição', accessor: 'condition' as keyof AggregatedProductPrice },
     { header: 'Mínimo (R$)', accessor: (i: AggregatedProductPrice): ReactNode => formatCurrencyBRL(i.minPriceBRL), className: 'font-semibold text-green-600' },
     { header: 'Fornecedor +Barato', accessor: 'cheapestSupplierName' as keyof AggregatedProductPrice },
@@ -86,6 +89,9 @@ export const MarketAnalysisPage: React.FC<{}> = () => {
       h.productName === product.productName &&
       h.model === product.model &&
       h.capacity === product.capacity &&
+      h.color === product.color &&
+      h.characteristics === product.characteristics &&
+      h.country === product.country &&
       h.condition === product.condition
     );
     const dateMap: Record<string, any> = {};
@@ -105,6 +111,9 @@ export const MarketAnalysisPage: React.FC<{}> = () => {
         h.productName === product.productName &&
         h.model === product.model &&
         h.capacity === product.capacity &&
+        h.color === product.color &&
+        h.characteristics === product.characteristics &&
+        h.country === product.country &&
         h.condition === product.condition
       ) {
         suppliersSet.add(suppliers.find(s => s.id === h.supplierId)?.name || h.supplierId);

--- a/features/SuppliersFeature.tsx
+++ b/features/SuppliersFeature.tsx
@@ -193,6 +193,9 @@ const AnalyzePricesTab: React.FC<AnalyzePricesTabProps> = ({
   const aggregatedColumns = useMemo(() => [
     { header: 'Produto', accessor: (item: AggregatedProductPrice): ReactNode => `${item.productName} ${item.model}`, className: 'font-medium' },
     { header: 'Capacidade', accessor: 'capacity' as keyof AggregatedProductPrice },
+    { header: 'Cor', accessor: 'color' as keyof AggregatedProductPrice },
+    { header: 'Características', accessor: 'characteristics' as keyof AggregatedProductPrice },
+    { header: 'País', accessor: 'country' as keyof AggregatedProductPrice },
     { header: 'Condição', accessor: 'condition' as keyof AggregatedProductPrice },
     { header: 'Média (R$)', accessor: (item: AggregatedProductPrice): ReactNode => formatCurrencyBRL(item.avgPriceBRL) },
     { header: 'Menor Preço (R$)', accessor: (item: AggregatedProductPrice): ReactNode => formatCurrencyBRL(item.minPriceBRL), className: 'font-semibold text-green-600' },
@@ -211,6 +214,9 @@ const AnalyzePricesTab: React.FC<AnalyzePricesTabProps> = ({
       h.productName === product.productName &&
       h.model === product.model &&
       h.capacity === product.capacity &&
+      h.color === product.color &&
+      h.characteristics === product.characteristics &&
+      h.country === product.country &&
       h.condition === product.condition
     );
     const dateMap: Record<string, any> = {};
@@ -230,6 +236,9 @@ const AnalyzePricesTab: React.FC<AnalyzePricesTabProps> = ({
         h.productName === product.productName &&
         h.model === product.model &&
         h.capacity === product.capacity &&
+        h.color === product.color &&
+        h.characteristics === product.characteristics &&
+        h.country === product.country &&
         h.condition === product.condition
       ) {
         suppliersSet.add(suppliers.find(s => s.id === h.supplierId)?.name || h.supplierId);
@@ -276,7 +285,7 @@ const AnalyzePricesTab: React.FC<AnalyzePricesTabProps> = ({
         </Card>
     </div>
     {selectedProduct && (
-        <Modal isOpen={!!selectedProduct} onClose={() => setSelectedProduct(null)} title={`Histórico: ${selectedProduct.productName} ${selectedProduct.model} ${selectedProduct.capacity} (${selectedProduct.condition})`} size="xl">
+        <Modal isOpen={!!selectedProduct} onClose={() => setSelectedProduct(null)} title={`Histórico: ${selectedProduct.productName} ${selectedProduct.model} ${selectedProduct.capacity} ${selectedProduct.color || ''} ${selectedProduct.characteristics || ''} ${selectedProduct.country || ''} (${selectedProduct.condition})`} size="xl">
             <div className="h-96">
                 <ResponsiveContainer width="100%" height="100%">
                     <LineChart data={buildChartData(selectedProduct)}>
@@ -364,6 +373,9 @@ export const SuppliersPage: React.FC<{}> = () => {
               productName: p.product,
               model: p.model,
               capacity: p.capacity,
+              color: p.color,
+              characteristics: p.characteristics,
+              country: p.country,
               condition: p.condition,
               priceBRL: p.priceBRL,
               dateRecorded: new Date().toISOString(),
@@ -379,21 +391,39 @@ export const SuppliersPage: React.FC<{}> = () => {
           await fetchAllHistoricalDataAndAggregate(); // Refresh data
       } 
   };
-  const handleExportAggregated = (profitMargin: number) => { const dataToExport = aggregatedData.map(item => ({ Produto: item.productName, Modelo: item.model, Capacidade: item.capacity, Condicao: item.condition, PrecoMedio_BRL: item.avgPriceBRL, MenorPreco_BRL: item.minPriceBRL, FornecedorMaisBarato: item.cheapestSupplierName, QtdFornecedores: item.supplierCount, PrecoComMargem_BRL: profitMargin > 0 ? parseFloat((item.minPriceBRL * (1 + profitMargin / 100)).toFixed(2)) : item.minPriceBRL, })); exportToCSV(dataToExport, `analise_fornecedores_${new Date().toISOString().split('T')[0]}.csv`); };
+  const handleExportAggregated = (profitMargin: number) => {
+      const dataToExport = aggregatedData.map(item => ({
+          Produto: item.productName,
+          Modelo: item.model,
+          Capacidade: item.capacity,
+          Cor: item.color,
+          Caracteristicas: item.characteristics,
+          Pais: item.country,
+          Condicao: item.condition,
+          PrecoMedio_BRL: item.avgPriceBRL,
+          MenorPreco_BRL: item.minPriceBRL,
+          FornecedorMaisBarato: item.cheapestSupplierName,
+          QtdFornecedores: item.supplierCount,
+          PrecoComMargem_BRL: profitMargin > 0 ? parseFloat((item.minPriceBRL * (1 + profitMargin / 100)).toFixed(2)) : item.minPriceBRL,
+      }));
+      exportToCSV(dataToExport, `analise_fornecedores_${new Date().toISOString().split('T')[0]}.csv`);
+  };
   
   const handleExportRaw = () => { 
-      const dataToExport = historicalProducts.map(item => ({ 
-          ID_Historico: item.id, 
+      const dataToExport = historicalProducts.map(item => ({
+          ID_Historico: item.id,
           ID_Fornecedor: item.supplierId,
-          // Supplier Name could be joined here if needed, but for raw, supplierId is key
-          Produto: item.productName, 
-          Modelo: item.model, 
-          Capacidade: item.capacity, 
-          Condicao: item.condition, 
-          Preco_BRL: item.priceBRL, 
+          Produto: item.productName,
+          Modelo: item.model,
+          Capacidade: item.capacity,
+          Cor: item.color,
+          Caracteristicas: item.characteristics,
+          Pais: item.country,
+          Condicao: item.condition,
+          Preco_BRL: item.priceBRL,
           DataRegistro: formatDateBR(item.dateRecorded, true),
           ID_Lista: item.listId || "N/A"
-      })); 
+      }));
       exportToCSV(dataToExport, `dados_historicos_precos_${new Date().toISOString().split('T')[0]}.csv`); 
   };
 

--- a/server/database.js
+++ b/server/database.js
@@ -40,6 +40,9 @@ function initializeDatabase() {
     db.run('ALTER TABLE clients ADD COLUMN cep TEXT', [], () => {});
     db.run('ALTER TABLE orders ADD COLUMN watchSize TEXT', [], () => {});
     db.run("ALTER TABLE users ADD COLUMN role TEXT DEFAULT 'user'", [], () => {});
+    db.run('ALTER TABLE historicalPrices ADD COLUMN color TEXT', [], () => {});
+    db.run('ALTER TABLE historicalPrices ADD COLUMN characteristics TEXT', [], () => {});
+    db.run('ALTER TABLE historicalPrices ADD COLUMN originCountry TEXT', [], () => {});
 
     db.run(`CREATE TABLE IF NOT EXISTS suppliers (
       id TEXT PRIMARY KEY,
@@ -61,6 +64,9 @@ function initializeDatabase() {
         productName TEXT NOT NULL,
         model TEXT NOT NULL,
         capacity TEXT,
+        color TEXT,
+        characteristics TEXT,
+        originCountry TEXT,
         condition TEXT,
         priceBRL REAL,
         dateRecorded TEXT NOT NULL,

--- a/types.ts
+++ b/types.ts
@@ -65,14 +65,17 @@ export interface Supplier {
 }
 
 export interface HistoricalParsedProduct {
-  id: string; 
-  supplierId: string; 
-  listId?: string; 
+  id: string;
+  supplierId: string;
+  listId?: string;
   userId?: string; // Associated with the user who created it
   productName: string;
   model: string;
   capacity: string;
-  condition: string; 
+  color?: string;
+  characteristics?: string;
+  country?: string;
+  condition: string;
   priceBRL: number | null;
   dateRecorded: string; // ISO string
 }
@@ -194,28 +197,34 @@ export interface NavItem {
 }
 
 export interface ParsedSupplierProduct {
-  id: string; 
-  supplierId: string; 
-  supplierName: string; 
+  id: string;
+  supplierId: string;
+  supplierName: string;
   product: string;
   model: string;
   capacity: string;
-  condition: string; 
+  color?: string;
+  characteristics?: string;
+  country?: string;
+  condition: string;
   priceBRL: number | null;
   priceUSD?: number | null;
-  originalTextLine?: string; 
+  originalTextLine?: string;
 }
 
 export interface AggregatedProductPrice {
-  key: string; 
+  key: string;
   productName: string;
   model: string;
   capacity: string;
+  color?: string;
+  characteristics?: string;
+  country?: string;
   condition: string;
   avgPriceBRL: number;
   minPriceBRL: number;
-  cheapestSupplierId: string; 
-  cheapestSupplierName: string; 
+  cheapestSupplierId: string;
+  cheapestSupplierName: string;
   supplierCount: number;
   allPrices: Array<{ supplierId: string; supplierName: string; priceBRL: number }>;
 }
@@ -237,6 +246,9 @@ export interface GeminiParsedProduct { // This is used for the expected structur
   modelo?: string;
   capacidade?: string;
   condicao?: string;
+  caracteristicas?: string;
+  pais?: string;
+  cor?: string;
   precoBRL?: number;
   precoUSD?: number;
 }


### PR DESCRIPTION
## Summary
- support new supplier fields (color, characteristics, country)
- extend Gemini parsing instructions
- store extra fields in DB and service layer
- show new columns in supplier analysis tables
- update data aggregation logic

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68484c32d47883228b5d6e17b2260b14