### PR TITLE
Remove color from Gemini extraction

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -917,11 +917,12 @@ app.post('/api/gemini/parse-supplier-list', authenticateToken, async (req, res) 
 
       REGRAS IMPORTANTES:
       1.  Ignore completamente qualquer texto introdutório, saudações, avisos, informações de contato ou regras de frete. Foque apenas nas linhas que descrevem os produtos e seus preços.
-      2.  Para cada produto, extraia: o nome do produto (produto), o modelo, a capacidade (capacidade), a condição (condicao), características como "e-sim" ou "chip físico" (caracteristicas), o país de fabricação (pais, ex: HN, CN, US) e o preço em BRL (precoBRL). Inclua a cor (cor) apenas se houver uma única opção com o mesmo preço.
+      2.  Para cada produto, extraia: o nome do produto (produto), o modelo, a capacidade (capacidade), a condição (condicao), características como "e-sim" ou "chip físico" (caracteristicas), o país de fabricação (pais, ex: HN, CN, US) e o preço em BRL (precoBRL). Ignore completamente a cor do produto.
       3.  "Condicao" deve conter apenas o estado do aparelho (ex: "Lacrado", "Novo", "CPO", "Seminovo"). Informações como "e-sim" ou "chip físico" vão para "caracteristicas" e abreviações como "HN" ou "CN" vão para "pais".
       4.  O campo "precoBRL" DEVE SER um número (float), não uma string. Remova "R$", "$", ".", e substitua "," por "." antes de converter para número. Ex: "R$6.650,00" se torna 6650.00. "(8,900)" se torna 8900.00.
       5.  A saída DEVE ser um array JSON válido. Nada além do array.
-      6.  Se o mesmo modelo e capacidade for listado com diferentes opções de cor e preços variados, ignore a cor e use somente o maior preço encontrado.
+      6.  Se o mesmo modelo e capacidade for listado com diferentes preços para cada cor, use somente o maior preço encontrado.
+      7.  Para MacBook, Mac mini e iMac, registre em "caracteristicas" o processador seguido do tamanho da tela (quando houver), por exemplo "M4 13\"" ou "M3 24\"".
 
       Exemplo de Saída Esperada:
       [
@@ -932,7 +933,6 @@ app.post('/api/gemini/parse-supplier-list', authenticateToken, async (req, res) 
           "condicao": "Lacrado",
           "caracteristicas": "E-SIM",
           "pais": "HN",
-          "cor": "Natural Titanium",
           "precoBRL": 6650.00
         },
         {
@@ -940,9 +940,8 @@ app.post('/api/gemini/parse-supplier-list', authenticateToken, async (req, res) 
           "modelo": "Pro 14",
           "capacidade": "512GB",
           "condicao": "Lacrado",
-          "caracteristicas": "",
+          "caracteristicas": "M4 14\"",
           "pais": "US",
-          "cor": "Space Gray",
           "precoBRL": 13500.00
         },
         {
@@ -950,9 +949,8 @@ app.post('/api/gemini/parse-supplier-list', authenticateToken, async (req, res) 
           "modelo": "24\"",
           "capacidade": "256GB",
           "condicao": "Lacrado",
-          "caracteristicas": "",
+          "caracteristicas": "M3 24\"",
           "pais": "US",
-          "cor": "Silver",
           "precoBRL": 10500.00
         },
         {
@@ -962,7 +960,6 @@ app.post('/api/gemini/parse-supplier-list', authenticateToken, async (req, res) 
           "condicao": "Novo",
           "caracteristicas": "GPS",
           "pais": "CN",
-          "cor": "Starlight",
           "precoBRL": 3500.00
         },
         {
@@ -972,7 +969,6 @@ app.post('/api/gemini/parse-supplier-list', authenticateToken, async (req, res) 
           "condicao": "Novo",
           "caracteristicas": "",
           "pais": "HN",
-          "cor": "",
           "precoBRL": 1200.00
         },
         {
@@ -980,9 +976,8 @@ app.post('/api/gemini/parse-supplier-list', authenticateToken, async (req, res) 
           "modelo": "M2",
           "capacidade": "512GB",
           "condicao": "Lacrado",
-          "caracteristicas": "",
+          "caracteristicas": "M2",
           "pais": "US",
-          "cor": "",
           "precoBRL": 6500.00
         },
         {
@@ -992,7 +987,6 @@ app.post('/api/gemini/parse-supplier-list', authenticateToken, async (req, res) 
           "condicao": "Lacrado",
           "caracteristicas": "Wi-Fi",
           "pais": "CN",
-          "cor": "Space Gray",
           "precoBRL": 4500.00
         },
         {
@@ -1002,7 +996,6 @@ app.post('/api/gemini/parse-supplier-list', authenticateToken, async (req, res) 
           "condicao": "Novo",
           "caracteristicas": "",
           "pais": "CN",
-          "cor": "Branco",
           "precoBRL": 950.00
         },
         {
@@ -1012,7 +1005,6 @@ app.post('/api/gemini/parse-supplier-list', authenticateToken, async (req, res) 
           "condicao": "Novo",
           "caracteristicas": "",
           "pais": "CN",
-          "cor": "Branco",
           "precoBRL": 650.00
         }
       ]

--- a/services/AppService.tsx
+++ b/services/AppService.tsx
@@ -194,7 +194,7 @@ export const parseSupplierListWithGemini = async ( textList: string, supplier: S
         product: p.produto || 'N/A',
         model: p.modelo || 'N/A',
         capacity: p.capacidade || 'N/A',
-        color: p.cor || undefined,
+        color: undefined,
         characteristics: p.caracteristicas || undefined,
         country: p.pais || undefined,
         condition: p.condicao || 'N/A',


### PR DESCRIPTION
## Summary
- update Gemini prompt: ignore color and specify Mac processor+screen rules
- update example output accordingly
- drop color field when mapping parsed products

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68485559e4f0832281cf952495959af3