### PR TITLE
Handle synonyms in supplier price lists

### DIFF
--- a/features/MarketAnalysisFeature.tsx
+++ b/features/MarketAnalysisFeature.tsx
@@ -6,6 +6,7 @@ import {
   getHistoricalParsedProducts,
   formatCurrencyBRL,
   deleteAllHistoricalProductsForUser,
+  normalizeProductCondition,
 } from '../services/AppService';
 import {
   Button,
@@ -92,7 +93,7 @@ export const MarketAnalysisPage: React.FC<{}> = () => {
       h.color === product.color &&
       h.characteristics === product.characteristics &&
       h.country === product.country &&
-      h.condition === product.condition
+      normalizeProductCondition(h.condition) === product.condition
     );
     const dateMap: Record<string, any> = {};
     filtered.forEach(item => {
@@ -114,7 +115,7 @@ export const MarketAnalysisPage: React.FC<{}> = () => {
         h.color === product.color &&
         h.characteristics === product.characteristics &&
         h.country === product.country &&
-        h.condition === product.condition
+        normalizeProductCondition(h.condition) === product.condition
       ) {
         suppliersSet.add(suppliers.find(s => s.id === h.supplierId)?.name || h.supplierId);
       }

--- a/features/SuppliersFeature.tsx
+++ b/features/SuppliersFeature.tsx
@@ -4,12 +4,13 @@ import {
   parseSupplierListWithGemini, 
   aggregateSupplierData,
   formatCurrencyBRL, exportToCSV,
-  getSuppliers, saveSupplier, deleteSupplier, getSupplierById, 
-  isGeminiAvailable, 
-  formatDateBR, 
+  getSuppliers, saveSupplier, deleteSupplier, getSupplierById,
+  isGeminiAvailable,
+  formatDateBR,
   saveHistoricalParsedProducts, // For saving new parsed data
   getHistoricalParsedProducts,  // For fetching all data for aggregation
-  deleteAllHistoricalProductsForUser // For clearing data
+  deleteAllHistoricalProductsForUser, // For clearing data
+  normalizeProductCondition
 } from '../services/AppService';
 import { Button, Textarea, Card, PageTitle, Alert, ResponsiveTable, Input, Modal, Select, Tabs, Tab } from '../components/SharedComponents';
 import {
@@ -217,7 +218,7 @@ const AnalyzePricesTab: React.FC<AnalyzePricesTabProps> = ({
       h.color === product.color &&
       h.characteristics === product.characteristics &&
       h.country === product.country &&
-      h.condition === product.condition
+      normalizeProductCondition(h.condition) === product.condition
     );
     const dateMap: Record<string, any> = {};
     filtered.forEach(item => {
@@ -239,7 +240,7 @@ const AnalyzePricesTab: React.FC<AnalyzePricesTabProps> = ({
         h.color === product.color &&
         h.characteristics === product.characteristics &&
         h.country === product.country &&
-        h.condition === product.condition
+        normalizeProductCondition(h.condition) === product.condition
       ) {
         suppliersSet.add(suppliers.find(s => s.id === h.supplierId)?.name || h.supplierId);
       }


### PR DESCRIPTION
## Summary
- add `normalizeProductCondition` helper to map synonyms like "Novo" to "Lacrado"
- use the new helper when aggregating historical supplier data
- compare historical data using normalized condition in market analysis and suppliers features

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6848591af0548322b2696e3e7e92573b