### PR TITLE
Fix supplier product grouping

### DIFF
--- a/features/MarketAnalysisFeature.tsx
+++ b/features/MarketAnalysisFeature.tsx
@@ -91,7 +91,6 @@ export const MarketAnalysisPage: React.FC<{}> = () => {
       h.model === product.model &&
       h.capacity === product.capacity &&
       h.color === product.color &&
-      h.characteristics === product.characteristics &&
       h.country === product.country &&
       normalizeProductCondition(h.condition) === product.condition
     );
@@ -113,7 +112,6 @@ export const MarketAnalysisPage: React.FC<{}> = () => {
         h.model === product.model &&
         h.capacity === product.capacity &&
         h.color === product.color &&
-        h.characteristics === product.characteristics &&
         h.country === product.country &&
         normalizeProductCondition(h.condition) === product.condition
       ) {

--- a/features/SuppliersFeature.tsx
+++ b/features/SuppliersFeature.tsx
@@ -216,7 +216,6 @@ const AnalyzePricesTab: React.FC<AnalyzePricesTabProps> = ({
       h.model === product.model &&
       h.capacity === product.capacity &&
       h.color === product.color &&
-      h.characteristics === product.characteristics &&
       h.country === product.country &&
       normalizeProductCondition(h.condition) === product.condition
     );
@@ -238,7 +237,6 @@ const AnalyzePricesTab: React.FC<AnalyzePricesTabProps> = ({
         h.model === product.model &&
         h.capacity === product.capacity &&
         h.color === product.color &&
-        h.characteristics === product.characteristics &&
         h.country === product.country &&
         normalizeProductCondition(h.condition) === product.condition
       ) {

--- a/services/AppService.tsx
+++ b/services/AppService.tsx
@@ -413,7 +413,7 @@ export const aggregateSupplierData = async (historicalData: HistoricalParsedProd
     dataToUse.forEach(item => {
         if (!item.supplierId) return;
         const normCond = normalizeProductCondition(item.condition);
-        const productKey = `${item.productName?.toLowerCase().trim()}-${item.model?.toLowerCase().trim()}-${item.capacity?.toLowerCase().trim()}-${item.color?.toLowerCase().trim() || ''}-${item.characteristics?.toLowerCase().trim() || ''}-${item.country?.toLowerCase().trim() || ''}-${normCond.toLowerCase()}`;
+        const productKey = `${item.productName?.toLowerCase().trim()}-${item.model?.toLowerCase().trim()}-${item.capacity?.toLowerCase().trim()}-${item.color?.toLowerCase().trim() || ''}-${item.country?.toLowerCase().trim() || ''}-${normCond.toLowerCase()}`;
         const supplierProductKey = `${item.supplierId}-${productKey}`;
         if (!latestPricesMap.has(supplierProductKey) && item.priceBRL !== null && item.priceBRL !== undefined) {
             latestPricesMap.set(supplierProductKey, item);
@@ -422,7 +422,7 @@ export const aggregateSupplierData = async (historicalData: HistoricalParsedProd
     const latestPriceItems = Array.from(latestPricesMap.values());
     latestPriceItems.forEach(item => {
         const normCond = normalizeProductCondition(item.condition);
-        const key = `${item.productName?.toLowerCase().trim()}-${item.model?.toLowerCase().trim()}-${item.capacity?.toLowerCase().trim()}-${item.color?.toLowerCase().trim() || ''}-${item.characteristics?.toLowerCase().trim() || ''}-${item.country?.toLowerCase().trim() || ''}-${normCond.toLowerCase()}`;
+        const key = `${item.productName?.toLowerCase().trim()}-${item.model?.toLowerCase().trim()}-${item.capacity?.toLowerCase().trim()}-${item.color?.toLowerCase().trim() || ''}-${item.country?.toLowerCase().trim() || ''}-${normCond.toLowerCase()}`;
         if (!productMap.has(key)) {
             productMap.set(key, { pricesBySupplier: new Map(), itemsInfo: { productName: item.productName, model: item.model, capacity: item.capacity, color: item.color, characteristics: item.characteristics, country: item.country, condition: normCond } });
         }


### PR DESCRIPTION
## Summary
- avoid splitting aggregated products when only characteristics differ
- update analysis features to ignore characteristics when generating charts

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68485db203288322aa8cdcd841e26460