### PR TITLE
Add chip field to historical price model

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -43,6 +43,7 @@ function initializeDatabase() {
     db.run('ALTER TABLE historicalPrices ADD COLUMN color TEXT', [], () => {});
     db.run('ALTER TABLE historicalPrices ADD COLUMN characteristics TEXT', [], () => {});
     db.run('ALTER TABLE historicalPrices ADD COLUMN originCountry TEXT', [], () => {});
+    db.run('ALTER TABLE historicalPrices ADD COLUMN chip TEXT', [], () => {});
 
     db.run(`CREATE TABLE IF NOT EXISTS suppliers (
       id TEXT PRIMARY KEY,
@@ -66,6 +67,7 @@ function initializeDatabase() {
         capacity TEXT,
         color TEXT,
         characteristics TEXT,
+        chip TEXT,
         originCountry TEXT,
         condition TEXT,
         priceBRL REAL,

--- a/server/server.js
+++ b/server/server.js
@@ -595,9 +595,9 @@ app.post('/api/suppliers/prices/historical', authenticateToken, (req, res) => {
 
     const insertSql = `INSERT INTO historicalPrices (
         id, userId, supplierId, listId, productName, model, capacity,
-        color, characteristics, originCountry,
+        color, characteristics, chip, originCountry,
         condition, priceBRL, dateRecorded
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
 
     // Use the underlying sqlite3 database instance for transactional inserts
     db.db.serialize(() => {
@@ -613,6 +613,7 @@ app.post('/api/suppliers/prices/historical', authenticateToken, (req, res) => {
                 p.capacity,
                 p.color || null,
                 p.characteristics || null,
+                p.chip || null,
                 p.originCountry || null,
                 p.condition,
                 p.priceBRL !== undefined && p.priceBRL !== null ? parseFloat(p.priceBRL) : null,

--- a/types.ts
+++ b/types.ts
@@ -74,6 +74,7 @@ export interface HistoricalParsedProduct {
   capacity: string;
   color?: string;
   characteristics?: string;
+  chip?: string;
   country?: string;
   condition: string;
   priceBRL: number | null;


### PR DESCRIPTION
## Summary
- extend `HistoricalParsedProduct` with optional `chip` field
- support `chip` column in historicalPrices DB table
- store `chip` value when inserting historical prices

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684ae2513570832291f8eed03ced4193