### PR TITLE
Implement lucro percentage and screenshot export

### DIFF
--- a/features/SaleCalculatorFeature.tsx
+++ b/features/SaleCalculatorFeature.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect, ReactNode } from 'react';
-import { PageTitle, Card, Input, Select, ResponsiveTable } from '../components/SharedComponents';
+import React, { useState, useEffect, ReactNode, useRef } from 'react';
+import { PageTitle, Card, Input, Select, ResponsiveTable, Button, ClipboardDocumentIcon } from '../components/SharedComponents';
+import html2canvas from 'html2canvas';
 import {
   formatCurrencyBRL,
   parseBRLCurrencyStringToNumber,
@@ -17,6 +18,9 @@ export const SaleCalculatorPage: React.FC<{}> = () => {
   const [productPrice, setProductPrice] = useState(0);
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>(PaymentMethod.A_VISTA);
   const [calculationResults, setCalculationResults] = useState<CalculatedCardFeeResult[]>([]);
+  const [profitPercentInput, setProfitPercentInput] = useState('0');
+  const [profitPercent, setProfitPercent] = useState(0);
+  const printRef = useRef<HTMLDivElement>(null);
 
   const handlePriceChange = (value: string) => {
     setProductPriceInput(value);
@@ -28,14 +32,35 @@ export const SaleCalculatorPage: React.FC<{}> = () => {
     setProductPriceInput(formatNumberToBRLCurrencyInput(productPrice));
   };
 
+  const handleProfitChange = (value: string) => {
+    setProfitPercentInput(value);
+    const numeric = parseFloat(value.replace(',', '.'));
+    setProfitPercent(isNaN(numeric) ? 0 : numeric);
+  };
+
+  const totalWithProfit = productPrice * (1 + profitPercent / 100) + SHIPPING_COST;
+
+  const handleExportImage = async () => {
+    if (!printRef.current) return;
+    const elementsToHide = printRef.current.querySelectorAll('.hide-on-export');
+    elementsToHide.forEach(el => el.classList.add('screenshot-hidden'));
+    const canvas = await html2canvas(printRef.current as HTMLElement);
+    elementsToHide.forEach(el => el.classList.remove('screenshot-hidden'));
+    const img = canvas.toDataURL('image/png');
+    const link = document.createElement('a');
+    link.href = img;
+    link.download = 'calculo-venda.png';
+    link.click();
+  };
+
   useEffect(() => {
     if (paymentMethod === PaymentMethod.CARTAO_CREDITO && productPrice > 0) {
-      const total = productPrice + SHIPPING_COST;
+      const total = productPrice * (1 + profitPercent / 100) + SHIPPING_COST;
       setCalculationResults(calculateCreditCardFees(total));
     } else {
       setCalculationResults([]);
     }
-  }, [paymentMethod, productPrice]);
+  }, [paymentMethod, productPrice, profitPercent]);
 
   const columns = [
     { header: 'Nº Parcelas', accessor: (item: CalculatedCardFeeResult): ReactNode => `${item.installments}x` },
@@ -43,7 +68,7 @@ export const SaleCalculatorPage: React.FC<{}> = () => {
     { header: 'Valor a Cobrar (R$)', accessor: (item: CalculatedCardFeeResult): ReactNode => formatCurrencyBRL(item.amountToChargeCustomer), className: 'font-semibold text-blue-600' },
     { header: 'Valor da Parcela (R$)', accessor: (item: CalculatedCardFeeResult): ReactNode => formatCurrencyBRL(item.installmentValue) },
     { header: 'Custo Adicional (R$)', accessor: (item: CalculatedCardFeeResult): ReactNode => formatCurrencyBRL(item.additionalCostToCustomer), className: 'text-orange-600' },
-    { header: 'Líquido p/ Blu Imports (R$)', accessor: (item: CalculatedCardFeeResult): ReactNode => formatCurrencyBRL(item.netValueForBluImports), className: 'text-green-600' },
+    { header: 'Líquido p/ Blu Imports (R$)', accessor: (item: CalculatedCardFeeResult): ReactNode => formatCurrencyBRL(item.netValueForBluImports), className: 'text-green-600 hide-on-export', headerClassName: 'hide-on-export' },
   ];
 
   return (
@@ -74,6 +99,15 @@ export const SaleCalculatorPage: React.FC<{}> = () => {
             value={formatNumberToBRLCurrencyInput(SHIPPING_COST)}
             disabled
           />
+          <Input
+            label="Lucro (%)"
+            id="profit"
+            name="profit"
+            type="number"
+            value={profitPercentInput}
+            onChange={(e) => handleProfitChange(e.target.value)}
+            placeholder="0"
+          />
           <Select
             label="Método de Pagamento"
             id="paymentMethod"
@@ -85,18 +119,22 @@ export const SaleCalculatorPage: React.FC<{}> = () => {
         </div>
       </Card>
       {paymentMethod === PaymentMethod.CARTAO_CREDITO && calculationResults.length > 0 && (
-        <Card title="Simulação de Cartão de Crédito">
-          <p className="text-sm text-gray-600 mb-2">
-            Total com frete: <strong>{formatCurrencyBRL(productPrice + SHIPPING_COST)}</strong>
-          </p>
-          <ResponsiveTable columns={columns} data={calculationResults} rowKeyAccessor="installments" emptyStateMessage="Nenhum resultado" />
+        <Card title="Simulação de Cartão de Crédito" actions={<Button variant="secondary" onClick={handleExportImage} leftIcon={<ClipboardDocumentIcon className="h-5 w-5" />}>Exportar Imagem</Button>}>
+          <div ref={printRef}>
+            <p className="text-sm text-gray-600 mb-2 hide-on-export">
+              Total com frete e lucro: <strong>{formatCurrencyBRL(totalWithProfit)}</strong>
+            </p>
+            <ResponsiveTable columns={columns} data={calculationResults} rowKeyAccessor="installments" emptyStateMessage="Nenhum resultado" />
+          </div>
         </Card>
       )}
       {paymentMethod !== PaymentMethod.CARTAO_CREDITO && productPrice > 0 && (
-        <Card title="Resumo">
-          <p className="text-sm">Produto: <strong>{productName || 'N/A'}</strong></p>
-          <p className="text-sm">Método de Pagamento: <strong>{paymentMethod}</strong></p>
-          <p className="text-sm">Total a Receber: <strong>{formatCurrencyBRL(productPrice + SHIPPING_COST)}</strong></p>
+        <Card title="Resumo" actions={<Button variant="secondary" onClick={handleExportImage} leftIcon={<ClipboardDocumentIcon className="h-5 w-5" />}>Exportar Imagem</Button>}>
+          <div ref={printRef}>
+            <p className="text-sm">Produto: <strong>{productName || 'N/A'}</strong></p>
+            <p className="text-sm">Método de Pagamento: <strong>{paymentMethod}</strong></p>
+            <p className="text-sm">Total a Receber: <strong>{formatCurrencyBRL(totalWithProfit)}</strong></p>
+          </div>
         </Card>
       )}
     </div>

--- a/index.css
+++ b/index.css
@@ -6,3 +6,8 @@ body {
   background-color: #ffffff;
   color: #000000;
 }
+
+/* Utility class to hide elements when generating screenshots */
+.screenshot-hidden {
+  display: none !important;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@google/genai": "^1.3.0",
+        "html2canvas": "^1.4.1",
         "lucide-react": "^0.513.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -1167,6 +1168,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1510,6 +1520,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -2341,6 +2360,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/http-errors": {
@@ -3953,6 +3985,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -4128,6 +4169,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/uuid": {
       "version": "11.1.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.3.0",
+    "html2canvas": "^1.4.1",
     "lucide-react": "^0.513.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",


### PR DESCRIPTION
## Summary
- add lucro% input on Calculadora de Venda
- allow exporting the results card as an image
- hide frete info and Blu Imports column when exporting
- include new css utility for hiding during screenshots
- add html2canvas dependency

## Testing
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dc16ad1d08322bca6734f04580fc9