### PR TITLE
Add occurrences tracking page

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,6 +4,7 @@ import React, { useState, ReactNode, useEffect, useCallback } from 'react';
 import { HashRouter, Routes, Route, Link, useLocation, Navigate, useNavigate } from 'react-router-dom';
 import { AuthProvider, LoginPage, AuthGuard, useAuth } from './Auth';
 import { OrdersPage } from './features/OrdersFeature';
+import OrderOccurrencesPage from './features/OrderOccurrencesFeature';
 import { CalendarPage } from './features/CalendarFeature';
 import { SuppliersPage } from './features/SuppliersFeature';
 import MarketAnalysisPage from './features/MarketAnalysisFeature';
@@ -368,6 +369,7 @@ const App: React.FC<{}> = () => {
                     <Route path="/" element={<DashboardHomePage />} />
                     <Route path="/clients/*" element={<ClientsPage />} />
                     <Route path="/orders/*" element={<OrdersPage />} />
+                    <Route path="/orders/:orderId/occurrences" element={<OrderOccurrencesPage />} />
                     <Route path="/calendar" element={<CalendarPage />} />
                     <Route path="/suppliers" element={<SuppliersPage />} />
                     <Route path="/market-analysis" element={<MarketAnalysisPage />} />

--- a/features/OrderOccurrencesFeature.tsx
+++ b/features/OrderOccurrencesFeature.tsx
@@ -1,0 +1,153 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  getOrderById,
+  getOrderOccurrences,
+  saveOrderOccurrence,
+  deleteOrderOccurrence,
+  formatDateBR,
+} from '../services/AppService';
+import {
+  Order,
+  OrderOccurrence,
+  OCCURRENCE_TYPE_OPTIONS,
+  OCCURRENCE_STATUS_OPTIONS,
+  OccurrenceType,
+  OccurrenceStatus,
+} from '../types';
+import {
+  PageTitle,
+  Card,
+  Select,
+  Textarea,
+  Input,
+  Button,
+  Alert,
+} from '../components/SharedComponents';
+import { v4 as uuidv4 } from 'uuid';
+
+const OrderOccurrencesPage: React.FC = () => {
+  const { orderId } = useParams<{ orderId: string }>();
+  const navigate = useNavigate();
+  const [order, setOrder] = useState<Order | null>(null);
+  const [occurrences, setOccurrences] = useState<OrderOccurrence[]>([]);
+  const [type, setType] = useState<OccurrenceType>(OccurrenceType.PRODUTO_COM_DEFEITO);
+  const [description, setDescription] = useState('');
+  const [status, setStatus] = useState<OccurrenceStatus>(OccurrenceStatus.ABERTO);
+  const [responsible, setResponsible] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (orderId) {
+      getOrderById(orderId)
+        .then(o => setOrder(o || null))
+        .catch(console.error);
+      getOrderOccurrences(orderId).then(setOccurrences).catch(console.error);
+    }
+  }, [orderId]);
+
+  const handleSubmit = async () => {
+    if (!orderId) return;
+    try {
+      const newOccurrence: OrderOccurrence = {
+        id: uuidv4(),
+        orderId,
+        type,
+        description,
+        status,
+        responsible: responsible || undefined,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        attachments: [],
+      };
+      const saved = await saveOrderOccurrence(orderId, newOccurrence);
+      setOccurrences(prev => [...prev, saved]);
+      setDescription('');
+      setResponsible('');
+      setType(OccurrenceType.PRODUTO_COM_DEFEITO);
+      setStatus(OccurrenceStatus.ABERTO);
+    } catch (e: any) {
+      setError(e.message || 'Erro ao salvar ocorrência');
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!orderId) return;
+    if (!window.confirm('Remover ocorrência?')) return;
+    await deleteOrderOccurrence(orderId, id);
+    setOccurrences(prev => prev.filter(o => o.id !== id));
+  };
+
+  return (
+    <div>
+      <PageTitle
+        title={`Ocorrências`}
+        subtitle={order ? `${order.productName} - ${order.customerName}` : ''}
+        actions={<Button onClick={() => navigate(-1)}>Voltar</Button>}
+      />
+      <Card title="Registrar Nova Ocorrência">
+        <div className="space-y-2">
+          <Select
+            id="occType"
+            label="Tipo"
+            options={OCCURRENCE_TYPE_OPTIONS.map(t => ({ value: t, label: t }))}
+            value={type}
+            onChange={e => setType(e.target.value as OccurrenceType)}
+          />
+          <Textarea
+            id="occDesc"
+            label="Descrição"
+            rows={3}
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+          />
+          <Select
+            id="occStatus"
+            label="Status"
+            options={OCCURRENCE_STATUS_OPTIONS.map(s => ({ value: s, label: s }))}
+            value={status}
+            onChange={e => setStatus(e.target.value as OccurrenceStatus)}
+          />
+          <Input
+            id="occResp"
+            label="Responsável Interno"
+            value={responsible}
+            onChange={e => setResponsible(e.target.value)}
+          />
+          {error && <Alert type="error" message={error} />}
+          <Button onClick={handleSubmit}>Adicionar</Button>
+        </div>
+      </Card>
+      <Card title="Histórico" className="mt-4">
+        {occurrences.length === 0 ? (
+          <p className="text-sm text-gray-500">Nenhuma ocorrência registrada.</p>
+        ) : (
+          <ul className="space-y-3">
+            {occurrences.map(o => (
+              <li key={o.id} className="border-b pb-2 text-sm">
+                <p>
+                  <strong>Tipo:</strong> {o.type} - <strong>Status:</strong> {o.status}
+                </p>
+                <p>
+                  <strong>Responsável:</strong> {o.responsible || 'N/A'} -{' '}
+                  <strong>Abertura:</strong> {formatDateBR(o.createdAt, true)}
+                </p>
+                <p className="whitespace-pre-wrap">{o.description}</p>
+                <Button
+                  variant="link"
+                  size="sm"
+                  className="text-red-500"
+                  onClick={() => handleDelete(o.id)}
+                >
+                  Remover
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+export default OrderOccurrencesPage;

--- a/features/OrdersFeature.tsx
+++ b/features/OrdersFeature.tsx
@@ -995,7 +995,11 @@ export const OrdersPage = () => {
                 
                 <div><h4 className="text-md font-semibold mb-1 text-gray-800">Documentos:</h4> {orderToView.documents.length > 0 ? orderToView.documents.map(d => <span key={d.id} className="text-xs bg-gray-100 p-1 rounded mr-1">{d.name}</span>) : <span className="text-xs text-gray-500">Nenhum.</span>}</div>
                 <div><h4 className="text-md font-semibold mb-1 text-gray-800">Linha do Tempo:</h4><OrderStatusTimeline order={orderToView} /></div>
-                 <div className="flex justify-end space-x-2 mt-6"> <Button variant="secondary" onClick={() => { setOrderToView(null); handleOpenForm(orderToView); }}>Editar Encomenda</Button> <Button onClick={() => setOrderToView(null)}>Fechar</Button> </div>
+                 <div className="flex justify-end space-x-2 mt-6">
+                    <Button variant="secondary" onClick={() => { setOrderToView(null); handleOpenForm(orderToView); }}>Editar Encomenda</Button>
+                    <Button variant="secondary" onClick={() => { setOrderToView(null); navigate(`/orders/${orderToView.id}/occurrences`); }}>Ocorrências</Button>
+                    <Button onClick={() => setOrderToView(null)}>Fechar</Button>
+                 </div>
             </div>
         </Modal>
       )}

--- a/services/AppService.tsx
+++ b/services/AppService.tsx
@@ -2,10 +2,11 @@
 import { 
     Order, OrderStatus, ProductCondition, ParsedSupplierProduct, GeminiParsedProduct, 
     AggregatedProductPrice, Client, ClientType, PaymentMethod, BluFacilitaContractStatus, 
-    DocumentFile, Supplier, TodayTask, TaskType, CreditCardRate, CalculatedCardFeeResult, 
-    OrderCostItem, CostType, InternalNote, DashboardAlert, WeeklySummaryStats, 
-    DEFAULT_BLU_FACILITA_ANNUAL_INTEREST_RATE as DEFAULT_BF_RATE_CONST, 
-    ClientPayment, User, HistoricalParsedProduct 
+    DocumentFile, Supplier, TodayTask, TaskType, CreditCardRate, CalculatedCardFeeResult,
+    OrderCostItem, CostType, InternalNote, DashboardAlert, WeeklySummaryStats,
+    OrderOccurrence, OccurrenceStatus, OccurrenceType,
+    DEFAULT_BLU_FACILITA_ANNUAL_INTEREST_RATE as DEFAULT_BF_RATE_CONST,
+    ClientPayment, User, HistoricalParsedProduct
 } from '../types'; // Updated User type
 import { v4 as uuidv4 } from 'uuid';
 // --- CONSTANTS ---
@@ -476,6 +477,32 @@ export const addClientPayment = async (paymentData: Omit<ClientPayment, 'id'|'us
     // For now, client side BluFacilita update logic after payment is removed from here.
     // Assume backend handles it or order is re-fetched.
     return newPayment;
+};
+
+// --- Order Occurrence Services ---
+export const getOrderOccurrences = async (orderId: string): Promise<OrderOccurrence[]> => {
+    return apiClient<OrderOccurrence[]>(`/orders/${orderId}/occurrences`);
+};
+
+export const saveOrderOccurrence = async (
+    orderId: string,
+    occurrence: Omit<OrderOccurrence, 'id' | 'createdAt' | 'updatedAt' | 'orderId'> | OrderOccurrence
+): Promise<OrderOccurrence> => {
+    if ('id' in occurrence && occurrence.id) {
+        return apiClient<OrderOccurrence>(
+            `/orders/${orderId}/occurrences/${occurrence.id}`,
+            { method: 'PUT', body: JSON.stringify(occurrence) }
+        );
+    } else {
+        return apiClient<OrderOccurrence>(
+            `/orders/${orderId}/occurrences`,
+            { method: 'POST', body: JSON.stringify(occurrence) }
+        );
+    }
+};
+
+export const deleteOrderOccurrence = async (orderId: string, occurrenceId: string): Promise<void> => {
+    return apiClient<void>(`/orders/${orderId}/occurrences/${occurrenceId}`, { method: 'DELETE' });
 };
 
 // --- Order Cost Services ---

--- a/types.ts
+++ b/types.ts
@@ -84,9 +84,39 @@ export interface HistoricalParsedProduct {
 
 export interface InternalNote {
     id: string;
-    date: string; 
+    date: string;
     note: string;
-    userId?: string; 
+    userId?: string;
+}
+
+export enum OccurrenceType {
+    PRODUTO_COM_DEFEITO = 'Produto com defeito',
+    BATERIA_NAO_DURA = 'Bateria não dura',
+    PRODUTO_DANIFICADO = 'Produto danificado',
+    DEVOLUCAO_REEMBOLSO = 'Devolução/reembolso',
+    OUTRO = 'Outro',
+}
+export const OCCURRENCE_TYPE_OPTIONS: OccurrenceType[] = Object.values(OccurrenceType);
+
+export enum OccurrenceStatus {
+    ABERTO = 'Aberto',
+    EM_ANALISE = 'Em análise',
+    SOLUCIONADO = 'Solucionado',
+    REEMBOLSADO = 'Reembolsado',
+    SEM_SOLUCAO = 'Sem solução',
+}
+export const OCCURRENCE_STATUS_OPTIONS: OccurrenceStatus[] = Object.values(OccurrenceStatus);
+
+export interface OrderOccurrence {
+    id: string;
+    orderId: string;
+    type: OccurrenceType;
+    description: string;
+    status: OccurrenceStatus;
+    responsible?: string;
+    createdAt: string;
+    updatedAt: string;
+    attachments?: DocumentFile[];
 }
 
 export interface BluFacilitaInstallment {


### PR DESCRIPTION
## Summary
- track post-sale occurrences per order
- expose occurrence APIs in AppService
- create OrderOccurrencesFeature page
- link occurrences from order details
- add route for occurrences view

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684ebbe676208322a3262f1c1ed68e75