### PR TITLE
Fix undefined occurrences page

### DIFF
--- a/features/OrderOccurrencesFeature.tsx
+++ b/features/OrderOccurrencesFeature.tsx
@@ -42,7 +42,12 @@ const OrderOccurrencesPage: React.FC = () => {
       getOrderById(orderId)
         .then(o => setOrder(o || null))
         .catch(console.error);
-      getOrderOccurrences(orderId).then(setOccurrences).catch(console.error);
+      getOrderOccurrences(orderId)
+        .then(data => setOccurrences(Array.isArray(data) ? data : []))
+        .catch(err => {
+          console.error(err);
+          setOccurrences([]);
+        });
     }
   }, [orderId]);
 


### PR DESCRIPTION
## Summary
- prevent undefined OrderOccurrences state by defaulting to empty array

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684ebe9959c483229ea64702a50f31d6