### PR TITLE
Add section headers to order form steps

### DIFF
--- a/features/orders/steps/ClientProductStep.tsx
+++ b/features/orders/steps/ClientProductStep.tsx
@@ -101,11 +101,13 @@ export const ClientProductStep: React.FC<Props> = ({ state, dispatch, onAddNewCl
 
   return (
     <Card title="Detalhes do Cliente e Produto" className="h-full">
+      <h4 className="font-semibold text-gray-700 mb-2 mt-4 first:mt-0">Dados do Cliente</h4>
       <Combobox value={query} onChange={setQuery} onSelect={handleSelect} onAddNew={onAddNewClient} results={options} />
       {selectedClient?.isDefaulter && (
         <Alert type="warning" message={`Atenção: Cliente ${selectedClient.fullName} está marcado como inadimplente.`}
                details={selectedClient.defaulterNotes} className="mt-2" />
       )}
+      <h4 className="font-semibold text-gray-700 mb-2 mt-4 first:mt-0">Detalhes do Produto</h4>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
         <Select
           label="Produto"

--- a/features/orders/steps/ValuesStep.tsx
+++ b/features/orders/steps/ValuesStep.tsx
@@ -31,6 +31,7 @@ export const ValuesStep: React.FC<ValuesStepProps> = ({
     <>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <Card title="Valores, Fornecedor e Prazos" className="h-full">
+          <h4 className="font-semibold text-gray-700 mb-2 mt-4 first:mt-0">Valores e Fornecedor</h4>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <Select
               label="Fornecedor"
@@ -64,16 +65,19 @@ export const ValuesStep: React.FC<ValuesStepProps> = ({
             required
             containerClassName="mt-4"
           />
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
-            <Input
-              label="Valor de Venda (R$) (Opcional)"
-              id="sellingPrice"
-              name="sellingPrice"
-              type="number"
-              step="0.01"
-              value={String(state.sellingPrice || '')}
-              onChange={handleChange}
-            />
+          <Input
+            label="Valor de Venda (R$) (Opcional)"
+            id="sellingPrice"
+            name="sellingPrice"
+            type="number"
+            step="0.01"
+            value={String(state.sellingPrice || '')}
+            onChange={handleChange}
+            containerClassName="mt-4"
+          />
+
+          <h4 className="font-semibold text-gray-700 mb-2 mt-4 first:mt-0">Prazos e Status</h4>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <Select
               label="Status Inicial"
               id="status"
@@ -112,7 +116,8 @@ export const ValuesStep: React.FC<ValuesStepProps> = ({
               containerClassName="mt-4"
             />
           )}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+          <h4 className="font-semibold text-gray-700 mb-2 mt-4 first:mt-0">Custos de Logística</h4>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <Input
               label="Custo Frete Fornecedor → Blu (R$)"
               id="shippingCostSupplierToBlu"


### PR DESCRIPTION
## Summary
- emphasize client and product info sections in order form
- group values step fields with new headers

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684ed995267883229fbdfb8e02807c16