### PR TITLE
Add credit card payment option

### DIFF
--- a/features/OrderDetailsPage.tsx
+++ b/features/OrderDetailsPage.tsx
@@ -276,7 +276,7 @@ const OrderDetailsPage: React.FC = () => {
               <ul className="list-disc pl-5 text-xs bg-gray-50 p-2 rounded border max-h-32 overflow-y-auto mt-1">
                 {clientPayments.map(p => (
                   <li key={p.id}>
-                    {formatDateBR(p.paymentDate)}: {formatCurrencyBRL(p.amountPaid)} ({p.paymentMethodUsed}){p.notes && <span className="text-gray-500"> - {p.notes}</span>}
+                    {formatDateBR(p.paymentDate)}: {formatCurrencyBRL(p.amountPaid)} ({p.paymentMethodUsed}{p.installments ? ` - ${p.installments}x` : ''}){p.notes && <span className="text-gray-500"> - {p.notes}</span>}
                   </li>
                 ))}
               </ul>

--- a/server/database.js
+++ b/server/database.js
@@ -45,6 +45,7 @@ function initializeDatabase() {
     db.run('ALTER TABLE historicalPrices ADD COLUMN characteristics TEXT', [], () => {});
     db.run('ALTER TABLE historicalPrices ADD COLUMN originCountry TEXT', [], () => {});
     db.run('ALTER TABLE historicalPrices ADD COLUMN chip TEXT', [], () => {});
+    db.run('ALTER TABLE clientPayments ADD COLUMN installments INTEGER', [], () => {});
 
     db.run(`CREATE TABLE IF NOT EXISTS suppliers (
       id TEXT PRIMARY KEY,
@@ -188,6 +189,7 @@ function initializeDatabase() {
         "paymentDate" TEXT NOT NULL,
         "amountPaid" REAL NOT NULL,
         "paymentMethodUsed" TEXT NOT NULL,
+        installments INTEGER,
         notes TEXT,
         FOREIGN KEY ("userId") REFERENCES users(id),
         FOREIGN KEY ("orderId") REFERENCES orders(id) ON DELETE CASCADE

--- a/server/server.js
+++ b/server/server.js
@@ -719,11 +719,11 @@ app.get('/api/orders/:orderId/payments', authenticateToken, (req, res) => {
 
 app.post('/api/orders/:orderId/payments', authenticateToken, (req, res) => {
     const orderId = req.params.orderId;
-    const { paymentDate, amountPaid, paymentMethodUsed, notes } = req.body;
+    const { paymentDate, amountPaid, paymentMethodUsed, installments, notes } = req.body;
     const paymentId = uuidv4();
-    const sql = `INSERT INTO clientPayments (id, "userId", "orderId", "paymentDate", "amountPaid", "paymentMethodUsed", notes)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7)`;
-    const params = [paymentId, req.user.id, orderId, paymentDate || new Date().toISOString(), amountPaid, paymentMethodUsed, notes];
+    const sql = `INSERT INTO clientPayments (id, "userId", "orderId", "paymentDate", "amountPaid", "paymentMethodUsed", installments, notes)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`;
+    const params = [paymentId, req.user.id, orderId, paymentDate || new Date().toISOString(), amountPaid, paymentMethodUsed, installments, notes];
     db.run(sql, params, function(err) {
         if (err) {
             console.error('Error saving client payment:', err.message);

--- a/types.ts
+++ b/types.ts
@@ -366,11 +366,12 @@ export interface WeeklySummaryStats {
 }
 
 export interface ClientPayment {
-    id: string; 
+    id: string;
     userId?: string;
     orderId: string;
     paymentDate: string; // ISO Date string
     amountPaid: number;
-    paymentMethodUsed: 'PIX' | 'Transferência Bancária' | 'Dinheiro' | 'Outro';
+    paymentMethodUsed: 'PIX' | 'Transferência Bancária' | 'Dinheiro' | 'Cartão de Crédito' | 'Outro';
+    installments?: number;
     notes?: string;
 }


### PR DESCRIPTION
## Summary
- support registering payments with credit card
- store number of installments when a credit card is used
- show installments in order details
- update database schema and API for the new field

## Testing
- `npm run build`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6850aa6b4f6883229b32d9dd148ef556