### PR TITLE
Add integrated order edit page

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import { HashRouter, Routes, Route, Link, useLocation, Navigate, useNavigate } f
 import { AuthProvider, LoginPage, AuthGuard, useAuth } from './Auth';
 import { OrdersPage } from './features/OrdersFeature';
 import OrderDetailsPage from './features/OrderDetailsPage';
+import OrderEditPage from './features/OrderEditPage';
 import OrderOccurrencesPage from './features/OrderOccurrencesFeature';
 import { CalendarPage } from './features/CalendarFeature';
 import { SuppliersPage } from './features/SuppliersFeature';
@@ -426,6 +427,7 @@ const App: React.FC<{}> = () => {
                     <Route path="/clients/*" element={<ClientsPage />} />
                     <Route path="/orders" element={<OrdersPage />} />
                     <Route path="/orders/:orderId" element={<OrderDetailsPage />} />
+                    <Route path="/orders/:orderId/edit" element={<OrderEditPage />} />
                     <Route path="/orders/:orderId/occurrences" element={<OrderOccurrencesPage />} />
                     <Route path="/calendar" element={<CalendarPage />} />
                     <Route path="/suppliers" element={<SuppliersPage />} />

--- a/features/OrderDetailsPage.tsx
+++ b/features/OrderDetailsPage.tsx
@@ -296,7 +296,7 @@ const OrderDetailsPage: React.FC = () => {
         </Card>
 
         <div className="flex justify-end space-x-2 mt-6">
-          <Button variant="secondary" onClick={() => navigate('/orders', { state: { prefillOrderData: order } })}>Editar Encomenda</Button>
+          <Button variant="secondary" onClick={() => navigate(`/orders/${order.id}/edit`)}>Editar Encomenda</Button>
           <Button variant="secondary" onClick={() => navigate(`/orders/${order.id}/occurrences`)}>Ocorrências</Button>
           <Button onClick={() => navigate('/orders')}>Voltar</Button>
           <Button variant="secondary" onClick={handleSendContract}>Enviar Contrato</Button>

--- a/features/OrderEditPage.tsx
+++ b/features/OrderEditPage.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { getOrderById, saveOrder } from '../services/AppService';
+import { Order } from '../types';
+import { PageTitle, Card, Spinner, Button } from '../components/SharedComponents';
+import { OrderForm } from './OrdersFeature';
+
+const OrderEditPage: React.FC = () => {
+  const { orderId } = useParams<{ orderId: string }>();
+  const navigate = useNavigate();
+  const [order, setOrder] = useState<Order | null>(null);
+
+  useEffect(() => {
+    if (orderId) {
+      getOrderById(orderId).then(o => setOrder(o || null)).catch(() => setOrder(null));
+    }
+  }, [orderId]);
+
+  const handleSave = async (updated: Order) => {
+    await saveOrder(updated);
+    navigate(`/orders/${updated.id}`);
+  };
+
+  if (!order) {
+    return (
+      <div className="flex justify-center p-6">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <PageTitle
+        title="Editar Encomenda"
+        subtitle={`${order.productName} ${order.model}`}
+        actions={<Button onClick={() => navigate(`/orders/${order.id}`)}>Cancelar</Button>}
+      />
+      <Card>
+        <OrderForm
+          isOpen={true}
+          onClose={() => navigate(`/orders/${order.id}`)}
+          onSave={handleSave}
+          initialOrder={order}
+          useModal={false}
+        />
+      </Card>
+    </div>
+  );
+};
+
+export default OrderEditPage;

--- a/features/OrdersFeature.tsx
+++ b/features/OrdersFeature.tsx
@@ -243,7 +243,18 @@ const orderFormReducer = (state: OrderFormState, action: OrderFormAction): Order
 const initialState: OrderFormState = { ...initialFormData, currentStep: 0 };
 
 
-interface OrderFormProps { isOpen: boolean; onClose: () => void; onSave: (order: Order) => Promise<void>; initialOrder?: Order | null; prefillData?: Partial<OrderFormPrefillData>; }
+interface OrderFormProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (order: Order) => Promise<void>;
+  initialOrder?: Order | null;
+  prefillData?: Partial<OrderFormPrefillData>;
+  /**
+   * When true the form is wrapped in a modal (default behaviour).
+   * When false the form is rendered inline on the page.
+   */
+  useModal?: boolean;
+}
 interface OrderFormPrefillData {
     sellingPrice?: number;
     downPayment?: number;
@@ -254,7 +265,7 @@ interface OrderFormPrefillData {
 }
 
 
-const OrderForm: React.FC<OrderFormProps> = ({ isOpen, onClose, onSave, initialOrder, prefillData }) => {
+export const OrderForm: React.FC<OrderFormProps> = ({ isOpen, onClose, onSave, initialOrder, prefillData, useModal = true }) => {
   const [state, dispatch] = useReducer(orderFormReducer, initialState);
   const formData = state;
   const [documents, setDocuments] = useState<DocumentFile[]>([]);
@@ -548,9 +559,7 @@ Observações: O valor desta nota fiscal refere-se exclusivamente ao serviço de
   const selectedClientDetails = formData.clientId ? clients.find(c => c.id === formData.clientId) : null;
 
 
-  return (
-    <>
-    <Modal isOpen={isOpen} onClose={onClose} title={initialOrder ? 'Editar Encomenda' : 'Adicionar Nova Encomenda'} size="3xl">
+  const formBody = (
       <form onSubmit={handleSubmit} className="space-y-6">
         {error && <Alert type="error" message={error} onClose={() => setError(null)} />}
         <Stepper steps={FORM_STEPS} currentStep={currentStep} />
@@ -600,7 +609,17 @@ Observações: O valor desta nota fiscal refere-se exclusivamente ao serviço de
             </div>
         </div>
       </form>
-    </Modal>
+  );
+
+  return (
+    <>
+    {useModal ? (
+      <Modal isOpen={isOpen} onClose={onClose} title={initialOrder ? 'Editar Encomenda' : 'Adicionar Nova Encomenda'} size="3xl">
+        {formBody}
+      </Modal>
+    ) : (
+      isOpen && <div className="max-w-3xl mx-auto">{formBody}</div>
+    )}
     {isProductNFModalOpen && (
       <Modal
         isOpen={isProductNFModalOpen}


### PR DESCRIPTION
## Summary
- expose `OrderForm` and allow inline rendering
- add new `OrderEditPage` for dedicated editing
- route `/orders/:orderId/edit` to the new page
- navigate to edit page from order details

## Testing
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850ac45c768832296bc0c4cdc934632