### PR TITLE
Refactor product pricing UI

### DIFF
--- a/features/ProductPricingDashboard.tsx
+++ b/features/ProductPricingDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { PageTitle, Card, Button, Input, Select, ResponsiveTable } from '../components/SharedComponents';
+import { PageTitle, Card, Button, Input, Select, Modal, Tabs, Tab, Toast } from '../components/SharedComponents';
 import { v4 as uuidv4 } from 'uuid';
 
 interface Category {
@@ -125,6 +125,10 @@ export const ProductPricingDashboardPage: React.FC = () => {
   const [categories, setCategories] = useState<Category[]>(loadCategories);
   const [globals, setGlobals] = useState<GlobalDefaults>(loadGlobals);
   const [products, setProducts] = useState<Product[]>(loadProducts);
+  const [categoryModalOpen, setCategoryModalOpen] = useState(false);
+  const [editingCategory, setEditingCategory] = useState<Category | null>(null);
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [dispTab, setDispTab] = useState<'Brasil' | 'EUA'>('Brasil');
 
   const [productForm, setProductForm] = useState<Omit<Product, 'id'>>({
     name: '',
@@ -149,6 +153,7 @@ export const ProductPricingDashboardPage: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
   useEffect(() => {
     saveCategories(categories);
@@ -162,13 +167,32 @@ export const ProductPricingDashboardPage: React.FC = () => {
     saveProducts(products);
   }, [products]);
 
-  const handleCategoryChange = (id: string, field: keyof Category, value: string) => {
-    setCategories(cats => cats.map(c => c.id === id ? { ...c, [field]: Number(value) } : c));
+  const openNewCategory = () => {
+    setEditingCategory({ id: '', name: '', dustBag: 0, packaging: 0 });
+    setCategoryModalOpen(true);
   };
 
-  const addCategory = () => {
-    const newCat: Category = { id: uuidv4(), name: 'Nova Categoria', dustBag: 0, packaging: 0 };
-    setCategories(prev => [...prev, newCat]);
+  const openEditCategory = (cat: Category) => {
+    setEditingCategory({ ...cat });
+    setCategoryModalOpen(true);
+  };
+
+  const saveCategory = (cat: Category) => {
+    if (cat.id) {
+      setCategories(prev => prev.map(c => c.id === cat.id ? cat : c));
+      setToastMessage('Categoria Atualizada');
+    } else {
+      const newCat = { ...cat, id: uuidv4() };
+      setCategories(prev => [...prev, newCat]);
+      setToastMessage('Categoria Salva');
+    }
+    setCategoryModalOpen(false);
+  };
+
+  const deleteCategory = (id: string) => {
+    setCategories(prev => prev.filter(c => c.id !== id));
+    setCategoryModalOpen(false);
+    setToastMessage('Categoria Excluída');
   };
 
   const handleGlobalChange = (field: keyof GlobalDefaults, value: string) => {
@@ -199,6 +223,7 @@ export const ProductPricingDashboardPage: React.FC = () => {
     const withoutId = { ...prod } as Omit<Product, 'id'>;
     withoutId.valorTabela = computeValorTabela(withoutId);
     setProductForm(withoutId);
+    setDispTab(prod.disp);
   };
 
   const resetForm = () => {
@@ -223,6 +248,7 @@ export const ProductPricingDashboardPage: React.FC = () => {
     };
     base.valorTabela = computeValorTabela(base);
     setProductForm(base);
+    setDispTab('Brasil');
   };
 
   const saveProduct = () => {
@@ -230,8 +256,10 @@ export const ProductPricingDashboardPage: React.FC = () => {
     const toSave: Product = { id: editingId ?? uuidv4(), ...productForm, valorTabela };
     if (editingId) {
       setProducts(prev => prev.map(p => p.id === editingId ? toSave : p));
+      setToastMessage('Produto Atualizado');
     } else {
       setProducts(prev => [...prev, toSave]);
+      setToastMessage('Produto Salvo');
     }
     resetForm();
   };
@@ -239,6 +267,7 @@ export const ProductPricingDashboardPage: React.FC = () => {
   const deleteProduct = (id: string) => {
     if (!window.confirm('Confirma a exclusão?')) return;
     setProducts(prev => prev.filter(p => p.id !== id));
+    setToastMessage('Produto Excluído');
   };
 
   const calcValues = (p: Product) => {
@@ -256,33 +285,39 @@ export const ProductPricingDashboardPage: React.FC = () => {
     return { valorVenda, custoConvertido, custoTotalProd, lucroFinal, parcelado: valorTabela / 12, custoTotal, valorTabela };
   };
 
-  const productColumns = [
-    { header: 'Disp', accessor: 'disp' as keyof Product },
-    { header: 'Produto', accessor: 'name' as keyof Product },
-    { header: 'Categoria', accessor: (item: Product) => categories.find(c => c.id === item.categoryId)?.name || '' },
-    { header: 'Valor de Tabela', accessor: (item: Product) => calcValues(item).valorTabela.toFixed(2) },
-    { header: 'Parcelado (12x)', accessor: (item: Product) => calcValues(item).parcelado.toFixed(2) },
-    { header: 'Valor de Venda', accessor: (item: Product) => calcValues(item).valorVenda.toFixed(2) },
-    { header: 'Custo Total', accessor: (item: Product) => calcValues(item).custoTotal.toFixed(2) },
-    { header: 'Lucro Final', accessor: (item: Product) => calcValues(item).lucroFinal.toFixed(2) },
-    { header: 'Custo BRL', accessor: (item: Product) => (item.custoBRL ?? 0).toFixed(2) },
-    { header: 'Custo USD', accessor: (item: Product) => (item.custoUSD ?? 0).toFixed(2) },
-    { header: 'Câmbio', accessor: (item: Product) => item.cambio.toFixed(2) },
-    { header: 'Custo Operacional', accessor: (item: Product) => item.custoOperacional.toFixed(2) },
-    { header: 'NFs (2%)', accessor: (item: Product) => item.nfPercent.toFixed(2) },
-    { header: 'NF Produto', accessor: (item: Product) => item.nfProduto.toFixed(2) },
-    { header: 'DustBag', accessor: (item: Product) => item.dustBag.toFixed(2) },
-    { header: 'Custos Embalagem', accessor: (item: Product) => item.packaging.toFixed(2) },
-    { header: 'Frete (Até a Blu e Até Cliente)', accessor: (item: Product) => item.frete.toFixed(2) },
-    { header: 'Custo Convertido', accessor: (item: Product) => calcValues(item).custoConvertido.toFixed(2) },
-    { header: 'Custo Total + Prod', accessor: (item: Product) => calcValues(item).custoTotalProd.toFixed(2) },
-    { header: 'Ações', accessor: (item: Product) => (
-      <div className="space-x-1">
-        <Button size="sm" variant="ghost" onClick={() => startEdit(item)}>Editar</Button>
-        <Button size="sm" variant="danger" onClick={() => deleteProduct(item.id)}>Excluir</Button>
-      </div>
-    ) },
-  ];
+
+  const CategoryModal = () => {
+    const [form, setForm] = useState<Category>(editingCategory || { id: '', name: '', dustBag: 0, packaging: 0 });
+
+    useEffect(() => {
+      if (editingCategory) setForm(editingCategory);
+    }, [editingCategory]);
+
+    if (!editingCategory) return null;
+
+    return (
+      <Modal
+        isOpen={categoryModalOpen}
+        onClose={() => setCategoryModalOpen(false)}
+        title={editingCategory.id ? 'Editar Categoria' : 'Nova Categoria'}
+        footer={(
+          <>
+            {editingCategory.id && (
+              <Button variant="danger" onClick={() => deleteCategory(editingCategory.id)}>Excluir</Button>
+            )}
+            <Button variant="secondary" onClick={() => setCategoryModalOpen(false)}>Cancelar</Button>
+            <Button onClick={() => saveCategory(form)}>Salvar</Button>
+          </>
+        )}
+      >
+        <div className="space-y-4">
+          <Input id="cat-name" label="Nome" value={form.name} onChange={e => setForm(prev => ({ ...prev, name: e.target.value }))} />
+          <Input id="cat-dust" label="DustBag" type="number" value={form.dustBag} onChange={e => setForm(prev => ({ ...prev, dustBag: Number(e.target.value) }))} />
+          <Input id="cat-pack" label="Custos Embalagem" type="number" value={form.packaging} onChange={e => setForm(prev => ({ ...prev, packaging: Number(e.target.value) }))} />
+        </div>
+      </Modal>
+    );
+  };
 
   return (
     <div className="space-y-6">
@@ -294,7 +329,7 @@ export const ProductPricingDashboardPage: React.FC = () => {
           <Input id="global-nfprod" label="NF Produto" type="number" value={globals.nfProduto} onChange={e => handleGlobalChange('nfProduto', e.target.value)} />
           <Input id="global-frete" label="Frete" type="number" value={globals.frete} onChange={e => handleGlobalChange('frete', e.target.value)} />
           <div className="flex items-end">
-            <Button onClick={addCategory}>Adicionar Nova Categoria</Button>
+            <Button onClick={openNewCategory}>Adicionar Nova Categoria</Button>
           </div>
         </div>
         <div className="overflow-x-auto">
@@ -304,19 +339,17 @@ export const ProductPricingDashboardPage: React.FC = () => {
                 <th className="px-2 py-1 text-left">Categoria</th>
                 <th className="px-2 py-1 text-right">DustBag</th>
                 <th className="px-2 py-1 text-right">Custos Embalagem</th>
+                <th className="px-2 py-1" />
               </tr>
             </thead>
             <tbody>
               {categories.map(cat => (
                 <tr key={cat.id}>
-                  <td className="px-2 py-1">
-                    <Input id={`name-${cat.id}`} value={cat.name} onChange={e => handleCategoryChange(cat.id, 'name' as any, e.target.value)} />
-                  </td>
-                  <td className="px-2 py-1">
-                    <Input id={`dust-${cat.id}`} type="number" value={cat.dustBag} onChange={e => handleCategoryChange(cat.id, 'dustBag', e.target.value)} />
-                  </td>
-                  <td className="px-2 py-1">
-                    <Input id={`pack-${cat.id}`} type="number" value={cat.packaging} onChange={e => handleCategoryChange(cat.id, 'packaging', e.target.value)} />
+                  <td className="px-2 py-1">{cat.name}</td>
+                  <td className="px-2 py-1 text-right">{cat.dustBag}</td>
+                  <td className="px-2 py-1 text-right">{cat.packaging}</td>
+                  <td className="px-2 py-1 text-right">
+                    <Button size="sm" variant="ghost" onClick={() => openEditCategory(cat)}>Editar</Button>
                   </td>
                 </tr>
               ))}
@@ -326,43 +359,33 @@ export const ProductPricingDashboardPage: React.FC = () => {
       </Card>
 
       <Card title="Cadastro / Edição de Produtos" bodyClassName="space-y-6 p-4">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <Input id="prod-name" label="Produto" value={productForm.name} onChange={e => handleProductField('name', e.target.value)} />
-          <Select id="prod-cat" label="Categoria" value={productForm.categoryId} onChange={e => handleProductField('categoryId', e.target.value)} options={categories.map(c => ({ value: c.id, label: c.name }))} />
-          <Select id="prod-disp" label="Disp" value={productForm.disp} onChange={e => handleProductField('disp', e.target.value as 'Brasil' | 'EUA')} options={[{ value: 'Brasil', label: 'Brasil' }, { value: 'EUA', label: 'EUA' }]} />
+        <div>
+          <h3 className="text-lg font-semibold">Informações Principais</h3>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-2">
+            <Input id="prod-name" label="Produto" value={productForm.name} onChange={e => handleProductField('name', e.target.value)} />
+            <Select id="prod-cat" label="Categoria" value={productForm.categoryId} onChange={e => handleProductField('categoryId', e.target.value)} options={categories.map(c => ({ value: c.id, label: c.name }))} />
+            <Input id="caixa" label="Caixa" value={productForm.caixa} onChange={e => handleProductField('caixa', e.target.value)} />
+          </div>
         </div>
 
-        <h3 className="text-lg font-semibold">Custos do Produto</h3>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <Input id="dustBag" label="DustBag" type="number" value={productForm.dustBag} onChange={e => handleProductField('dustBag', e.target.value)} />
-          <Input id="packaging" label="Custos Embalagem" type="number" value={productForm.packaging} onChange={e => handleProductField('packaging', e.target.value)} />
-          {productForm.disp === 'Brasil' && (
+        <Tabs className="mt-4">
+          <Tab label="Brasil" isActive={dispTab === 'Brasil'} onClick={() => { setDispTab('Brasil'); handleProductField('disp', 'Brasil'); }} />
+          <Tab label="EUA" isActive={dispTab === 'EUA'} onClick={() => { setDispTab('EUA'); handleProductField('disp', 'EUA'); }} />
+        </Tabs>
+
+        {dispTab === 'Brasil' && (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
             <Input id="custoBRL" label="Custo BRL" type="number" value={productForm.custoBRL} onChange={e => handleProductField('custoBRL', e.target.value)} />
-          )}
-          {productForm.disp === 'EUA' && (
-            <Input id="custoUSD" label="Custo USD" type="number" value={productForm.custoUSD} onChange={e => handleProductField('custoUSD', e.target.value)} />
-          )}
-          <Input id="cambio" label="Câmbio" type="number" value={productForm.cambio} onChange={e => handleProductField('cambio', e.target.value)} />
-        </div>
+          </div>
+        )}
 
-        <h3 className="text-lg font-semibold">Custos Operacionais</h3>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <Input id="custoOperacional" label="Custo Operacional" type="number" value={productForm.custoOperacional} onChange={e => handleProductField('custoOperacional', e.target.value)} />
-          <Input id="nfPercent" label="NFs (%)" type="number" step="0.01" value={productForm.nfPercent} onChange={e => handleProductField('nfPercent', e.target.value)} />
-          <Input id="nfProduto" label="NF Produto" type="number" value={productForm.nfProduto} onChange={e => handleProductField('nfProduto', e.target.value)} />
-          <Input id="frete" label="Frete" type="number" value={productForm.frete} onChange={e => handleProductField('frete', e.target.value)} />
-          <Input id="lucroPercent" label="% Lucro" type="number" value={productForm.lucroPercent} onChange={e => handleProductField('lucroPercent', e.target.value)} />
-          <Input id="caixa" label="Caixa" value={productForm.caixa} onChange={e => handleProductField('caixa', e.target.value)} />
-        </div>
-
-        <h3 className="text-lg font-semibold">Cálculo</h3>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <Input id="valorTabela" label="Valor de Tabela" type="number" value={productForm.valorTabela.toFixed(2)} disabled />
-        </div>
-
-        {productForm.disp === 'EUA' && (
-          <>
-            <h3 className="text-lg font-semibold">Custos de Importação</h3>
+        {dispTab === 'EUA' && (
+          <div className="space-y-4 mt-4">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <Input id="custoUSD" label="Custo USD" type="number" value={productForm.custoUSD} onChange={e => handleProductField('custoUSD', e.target.value)} />
+              <Input id="cambio" label="Câmbio" type="number" value={productForm.cambio} onChange={e => handleProductField('cambio', e.target.value)} />
+            </div>
+            <h4 className="text-md font-semibold">Custos de Importação</h4>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               <Input id="freteDeclarado" label="Frete Declarado" type="number" value={productForm.freteDeclarado || 0} onChange={e => handleProductField('freteDeclarado', e.target.value)} />
               <Input id="freteEuaBr" label="Frete EUA x BR" type="number" value={productForm.freteEuaBr || 0} onChange={e => handleProductField('freteEuaBr', e.target.value)} />
@@ -371,18 +394,97 @@ export const ProductPricingDashboardPage: React.FC = () => {
               <Input id="nomeDec" label="Nome Declarado" value={productForm.nomeDeclarado || ''} onChange={e => handleProductField('nomeDeclarado', e.target.value)} />
               <Input id="precoDec" label="Preço Declarado" type="number" value={productForm.precoDeclarado || 0} onChange={e => handleProductField('precoDeclarado', e.target.value)} />
             </div>
-          </>
+          </div>
         )}
 
-        <div className="flex justify-end space-x-2">
+        <div>
+          <h3 className="text-lg font-semibold mt-4">Custos Base</h3>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-2">
+            <Input id="dustBag" label="DustBag" type="number" value={productForm.dustBag} onChange={e => handleProductField('dustBag', e.target.value)} />
+            <Input id="packaging" label="Custos Embalagem" type="number" value={productForm.packaging} onChange={e => handleProductField('packaging', e.target.value)} />
+            <Input id="custoOperacional" label="Custo Operacional" type="number" value={productForm.custoOperacional} onChange={e => handleProductField('custoOperacional', e.target.value)} />
+            <Input id="frete" label="Frete" type="number" value={productForm.frete} onChange={e => handleProductField('frete', e.target.value)} />
+            <Input id="nfProduto" label="NF Produto" type="number" value={productForm.nfProduto} onChange={e => handleProductField('nfProduto', e.target.value)} />
+            <Input id="nfPercent" label="NFs (%)" type="number" step="0.01" value={productForm.nfPercent} onChange={e => handleProductField('nfPercent', e.target.value)} />
+          </div>
+        </div>
+
+        <div>
+          <h3 className="text-lg font-semibold mt-4">Valores de Venda</h3>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-2">
+            <Input id="lucroPercent" label="% Lucro" type="number" value={productForm.lucroPercent} onChange={e => handleProductField('lucroPercent', e.target.value)} />
+            <Input id="valorTabela" label="Valor de Tabela" type="number" value={productForm.valorTabela.toFixed(2)} disabled />
+          </div>
+        </div>
+
+        <div className="flex justify-end space-x-2 mt-4">
           <Button variant="secondary" onClick={resetForm}>Cancelar</Button>
           <Button onClick={saveProduct}>{editingId ? 'Atualizar Produto' : 'Salvar Novo Produto'}</Button>
         </div>
       </Card>
 
       <Card title="Produtos" bodyClassName="p-4">
-        <ResponsiveTable columns={productColumns} data={products} rowKeyAccessor="id" />
+        <div className="overflow-x-auto">
+          <table className="min-w-full table-auto">
+            <thead>
+              <tr>
+                <th className="px-2 py-1" />
+                <th className="px-2 py-1 text-left">Produto</th>
+                <th className="px-2 py-1 text-left">Categoria</th>
+                <th className="px-2 py-1 text-right">Valor de Tabela</th>
+                <th className="px-2 py-1 text-right">Lucro Final</th>
+                <th className="px-2 py-1" />
+              </tr>
+            </thead>
+            <tbody>
+              {products.map(p => {
+                const values = calcValues(p);
+                const isOpen = expandedId === p.id;
+                return (
+                  <React.Fragment key={p.id}>
+                    <tr>
+                      <td className="px-2 py-1 text-center">
+                        <Button variant="ghost" size="sm" onClick={() => setExpandedId(isOpen ? null : p.id)}>
+                          <i className={`heroicons-outline-${isOpen ? 'minus' : 'plus'} h-4 w-4`} />
+                        </Button>
+                      </td>
+                      <td className="px-2 py-1">{p.name}</td>
+                      <td className="px-2 py-1">{categories.find(c => c.id === p.categoryId)?.name}</td>
+                      <td className="px-2 py-1 text-right">{values.valorTabela.toFixed(2)}</td>
+                      <td className="px-2 py-1 text-right">{values.lucroFinal.toFixed(2)}</td>
+                      <td className="px-2 py-1 text-right space-x-1">
+                        <Button size="sm" variant="ghost" onClick={() => startEdit(p)}>Editar</Button>
+                        <Button size="sm" variant="danger" onClick={() => deleteProduct(p.id)}>Excluir</Button>
+                      </td>
+                    </tr>
+                    {isOpen && (
+                      <tr>
+                        <td colSpan={6} className="bg-gray-50 p-3">
+                          <div className="grid grid-cols-1 md:grid-cols-3 gap-2 text-sm">
+                            <span>Custo BRL: {(p.custoBRL ?? 0).toFixed(2)}</span>
+                            <span>Custo USD: {(p.custoUSD ?? 0).toFixed(2)}</span>
+                            <span>Câmbio: {p.cambio.toFixed(2)}</span>
+                            <span>Frete: {p.frete.toFixed(2)}</span>
+                            <span>Custo Operacional: {p.custoOperacional.toFixed(2)}</span>
+                            <span>NF Produto: {p.nfProduto.toFixed(2)}</span>
+                            <span>NFs (%): {p.nfPercent.toFixed(2)}</span>
+                            <span>DustBag: {p.dustBag.toFixed(2)}</span>
+                            <span>Embalagem: {p.packaging.toFixed(2)}</span>
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </React.Fragment>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       </Card>
+      <CategoryModal />
+      {toastMessage && (
+        <Toast message={toastMessage} onClose={() => setToastMessage(null)} />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- modernize product pricing page
- manage categories through a modal
- reorganize product form with tabs and grouped sections
- add collapsible product table rows and toast feedback

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68518f54deb883229cdb43f0e1952d29