### PR TITLE
Add product pricing persistence

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -227,6 +227,24 @@ function initializeDatabase() {
         FOREIGN KEY ("userId") REFERENCES users(id)
     )`);
 
+    db.run(`CREATE TABLE IF NOT EXISTS productPricing (
+        id TEXT PRIMARY KEY,
+        "userId" TEXT NOT NULL,
+        data TEXT NOT NULL,
+        updatedAt TEXT NOT NULL,
+        FOREIGN KEY ("userId") REFERENCES users(id)
+    )`);
+
+    db.run(`CREATE TABLE IF NOT EXISTS productPricingHistory (
+        id TEXT PRIMARY KEY,
+        "userId" TEXT NOT NULL,
+        productId TEXT NOT NULL,
+        price REAL NOT NULL,
+        recordedAt TEXT NOT NULL,
+        FOREIGN KEY ("userId") REFERENCES users(id),
+        FOREIGN KEY (productId) REFERENCES productPricing(id) ON DELETE CASCADE
+    )`);
+
     console.log('Database schema initialized/verified.');
   });
 }

--- a/services/AppService.tsx
+++ b/services/AppService.tsx
@@ -6,7 +6,8 @@ import {
     OrderCostItem, CostType, InternalNote, DashboardAlert, WeeklySummaryStats,
     OrderOccurrence, OccurrenceStatus, OccurrenceType,
     DEFAULT_BLU_FACILITA_ANNUAL_INTEREST_RATE as DEFAULT_BF_RATE_CONST,
-    ClientPayment, User, HistoricalParsedProduct, CustomTableRow
+    ClientPayment, User, HistoricalParsedProduct, CustomTableRow,
+    PricingProduct, PricingHistoryEntry
 } from '../types'; // Updated User type
 import { v4 as uuidv4 } from 'uuid';
 // --- CONSTANTS ---
@@ -531,6 +532,27 @@ export const addOrderCostItem = async (costItemData: Omit<OrderCostItem, 'id'|'u
 export const deleteOrderCostItem = async (costItemId: string): Promise<void> => {
     // This endpoint might need adjustment, e.g. /costs/:costItemId if costs are global with orderId foreign key
     return apiClient<void>(`/costs/${costItemId}`, { method: 'DELETE' });
+};
+
+// --- Product Pricing Services ---
+export const getPricingProducts = async (): Promise<PricingProduct[]> => {
+    return apiClient<PricingProduct[]>('/product-pricing');
+};
+
+export const savePricingProduct = async (product: PricingProduct): Promise<PricingProduct> => {
+    if (product.id) {
+        return apiClient<PricingProduct>(`/product-pricing/${product.id}`, { method: 'PUT', body: JSON.stringify(product) });
+    }
+    return apiClient<PricingProduct>('/product-pricing', { method: 'POST', body: JSON.stringify(product) });
+};
+
+export const deletePricingProduct = async (id: string): Promise<void> => {
+    return apiClient<void>(`/product-pricing/${id}`, { method: 'DELETE' });
+};
+
+export const getPricingHistory = async (productId?: string): Promise<PricingHistoryEntry[]> => {
+    const endpoint = productId ? `/product-pricing/history?productId=${productId}` : '/product-pricing/history';
+    return apiClient<PricingHistoryEntry[]>(endpoint);
 };
 
 // --- Custom Table Services ---

--- a/types.ts
+++ b/types.ts
@@ -81,6 +81,39 @@ export interface HistoricalParsedProduct {
   dateRecorded: string; // ISO string
 }
 
+export interface PricingProduct {
+  id: string;
+  name: string;
+  categoryId: string;
+  disp: 'Brasil' | 'EUA';
+  dustBag: number;
+  packaging: number;
+  custoBRL?: number;
+  custoUSD?: number;
+  cambio: number;
+  custoOperacional: number;
+  nfPercent: number;
+  nfProduto: number;
+  frete: number;
+  valorTabela: number;
+  lucroPercent: number;
+  caixa: string;
+  freteDeclarado?: number;
+  freteEuaBr?: number;
+  freteRedirecionador?: number;
+  impostoImportacao?: number;
+  nomeDeclarado?: string;
+  precoDeclarado?: number;
+}
+
+export interface PricingHistoryEntry {
+  id: string;
+  userId?: string;
+  productId: string;
+  price: number;
+  recordedAt: string;
+}
+
 
 export interface InternalNote {
     id: string;


### PR DESCRIPTION
## Summary
- persist pricing information in SQLite
- expose CRUD and history endpoints for product pricing
- add pricing service helpers
- load and save pricing data via backend

## Testing
- `npm run build`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6851948855188322a572b5cb20d468d2