### PR TITLE
Fix product save route

### DIFF
--- a/features/ProductPricingDashboard.tsx
+++ b/features/ProductPricingDashboard.tsx
@@ -227,7 +227,7 @@ export const ProductPricingDashboardPage: React.FC = () => {
   const saveProduct = async () => {
     const custoOperacional = computeCustoOperacional(productForm);
     const valorTabela = computeValorTabela({ ...productForm, custoOperacional });
-    const toSave: Product = { id: editingId ?? uuidv4(), ...productForm, custoOperacional, valorTabela };
+    const toSave: Product = { id: editingId ?? '', ...productForm, custoOperacional, valorTabela };
     try {
       await savePricingProduct(toSave);
       const items = await getPricingProducts();


### PR DESCRIPTION
## Summary
- fix product pricing dashboard to POST when saving new product

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68519987e29c832287d73d8d83664361