### PR TITLE
Add product seed script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Follow the steps below in order:
    ```bash
    cd server
    npm run init-db            # creates tables
+   npm run seed-products      # populate productPricing
    cd ..
    ```
 

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "init-db": "node database.js"
+    "init-db": "node database.js",
+    "seed-products": "node scripts/seedProducts.js"
   },
   "keywords": [
     "express",

--- a/server/scripts/products_data.txt
+++ b/server/scripts/products_data.txt
@@ -1,0 +1,538 @@
+I. iPhones Lacrados
+•
+iPhone 16 Pro Max 512GB (E-sim)
+◦
+Média de Valores: R$8.450,00
+◦
+Preço mais alto registrado: R$8.500,00 (Mega Storyia - cores Desert, Natural, Branco, Preto)
+•
+iPhone 16 Pro Max 256GB (E-sim)
+◦
+Média de Valores: R$7.010,00
+◦
+Preço mais alto registrado: R$7.450,00 (Azur Impex - CHIP)
+•
+iPhone 16 Pro 256GB (E-sim)
+◦
+Média de Valores: R$6.037,50
+◦
+Preço mais alto registrado: R$6.100,00 (Azur Impex - cores 🖤🩶🤍🧡)
+•
+iPhone 16 Pro 128GB (E-sim)
+◦
+Média de Valores: R$5.825,00
+◦
+Preço mais alto registrado: R$5.850,00 (Mega Storyia - cores Natural, Pteto)
+•
+iPhone 16 Plus 256GB (Chip Físico)
+◦
+Média de Valores: R$6.125,00
+◦
+Preço mais alto registrado: R$6.150,00 (Azur Impex - cor 💙)
+•
+iPhone 16 Plus 128GB (Chip Físico)
+◦
+Média de Valores: R$5.450,00
+◦
+Preço mais alto registrado: R$5.500,00 (Mega Storyia - cores preto, Branco)
+•
+iPhone 16 256GB
+◦
+Média de Valores: R$5.516,67
+◦
+Preço mais alto registrado: R$5.600,00 (Azur Impex - cor 💚)
+•
+iPhone 16 128GB (Chip Físico)
+◦
+Média de Valores: R$4.525,00
+◦
+Preço mais alto registrado: R$4.550,00 (Azur Impex - cores 🩷💚🤍🖤💙; Casimiro - todas as cores; Mega Storyia - cores Branco, Preto)
+•
+iPhone 16E 256GB
+◦
+Média de Valores: R$4.083,33
+◦
+Preço mais alto registrado: R$4.150,00 (Mega Storyia - cores preto, Branco)
+•
+iPhone 16E 128GB
+◦
+Média de Valores: R$3.550,00
+◦
+Preço mais alto registrado: R$3.650,00 (Mega Storyia - cores preto, Branco)
+•
+iPhone 15 Pro Max 256GB CPO
+◦
+Média de Valores: R$5.666,67
+◦
+Preço mais alto registrado: R$5.700,00 (Casimiro - cores Natural, Azul)
+•
+iPhone 15 Pro 256GB CPO
+◦
+Média de Valores: R$5.250,00
+◦
+Preço mais alto registrado: R$5.250,00 (Azur Impex - cor 🖤)
+•
+iPhone 15 Pro 128GB CPO
+◦
+Média de Valores: R$4.900,00
+◦
+Preço mais alto registrado: R$4.900,00 (Azur Impex - cor 🩶)
+•
+iPhone 15 256GB (Chip Físico)
+◦
+Média de Valores: R$5.000,00
+◦
+Preço mais alto registrado: R$5.050,00 (Mega Storyia - cor Preto)
+•
+iPhone 15 128GB (Chip Físico)
+◦
+Média de Valores: R$4.012,50
+◦
+Preço mais alto registrado: R$4.050,00 (Azur Impex - cores 💙🩷; Casimiro - cores Azul, Rosa)
+•
+iPhone 14 256GB
+◦
+Média de Valores: R$4.166,67
+◦
+Preço mais alto registrado: R$4.300,00 (Mega Storyia - cor Preto)
+•
+iPhone 14 128GB
+◦
+Média de Valores: R$3.395,00
+◦
+Preço mais alto registrado: R$3.450,00 (Casimiro - cores Preto, Azul, Branco; Mega Storyia - cores azul, Preto, Branco)
+•
+iPhone 13 128GB (Chip Físico)
+◦
+Média de Valores: R$2.967,50
+◦
+Preço mais alto registrado: R$2.990,00 (Casimiro - cor Branco; Mega Storyia - cores Preto, Branco)
+•
+iPhone 12 64GB
+◦
+Média de Valores: R$2.400,00
+◦
+Preço mais alto registrado: R$2.450,00 (Azur Impex - cores 🖤💜💚)
+•
+iPhone 11 64GB
+◦
+Média de Valores: R$2.200,00
+◦
+Preço mais alto registrado: R$2.200,00 (Azur Impex - cor 🖤)
+II. iPads Lacrados
+•
+iPad 9 64GB
+◦
+Média de Valores: R$1.850,00
+◦
+Preço mais alto registrado: R$1.850,00 (Azur Impex - cor 🖤)
+•
+iPad 9 256GB (Wi-Fi)
+◦
+Média de Valores: R$2.350,00
+◦
+Preço mais alto registrado: R$2.400,00 (Azur Impex - cores 🖤🤍)
+•
+iPad 10 64GB (Wi-Fi)
+◦
+Média de Valores: R$2.105,00
+◦
+Preço mais alto registrado: R$2.180,00 (Azur Impex - cores 🤍🩷)
+•
+iPad 10 256GB (Wi-Fi)
+◦
+Média de Valores: R$2.730,00
+◦
+Preço mais alto registrado: R$2.850,00 (Azur Impex - cores 💙🩷🤍)
+•
+iPad 11 128GB (Wi-Fi)
+◦
+Média de Valores: R$2.412,50
+◦
+Preço mais alto registrado: R$2.550,00 (Mega Storyia - cores Silver, Azul, Rosa)
+•
+iPad 11 256GB (Wi-Fi)
+◦
+Média de Valores: R$3.132,50
+◦
+Preço mais alto registrado: R$3.350,00 (Mega Storyia - cores Silver, Azul)
+•
+iPad Mini 7 128GB (Wi-Fi)
+◦
+Média de Valores: R$3.100,00
+◦
+Preço mais alto registrado: R$3.100,00 (Azur Impex - cores 💙🖤💛; Casimiro - cores Azul, Starlight)
+•
+iPad Mini 7 256GB (Wi-Fi)
+◦
+Média de Valores: R$3.616,67
+◦
+Preço mais alto registrado: R$3.650,00 (Azur Impex - cores 💙💛💜🖤)
+•
+iPad Air 5 64GB
+◦
+Média de Valores: R$3.400,00
+◦
+Preço mais alto registrado: R$3.400,00 (Azur Impex - cor 💙)
+•
+iPad Air M2 11 polegadas 256GB
+◦
+Média de Valores: R$4.300,00
+◦
+Preço mais alto registrado: R$4.450,00 (Azur Impex - cores 💜💙🖤)
+•
+iPad Air M2 11 polegadas 512GB
+◦
+Média de Valores: R$5.650,00
+◦
+Preço mais alto registrado: R$5.650,00 (Azur Impex - cor 💛)
+•
+iPad Air M2 13 polegadas 128GB
+◦
+Média de Valores: R$5.050,00
+◦
+Preço mais alto registrado: R$5.050,00 (Azur Impex - cores 💙🖤)
+•
+iPad Air M2 13 polegadas 256GB
+◦
+Média de Valores: R$5.600,00
+◦
+Preço mais alto registrado: R$5.600,00 (Azur Impex - cores 💛💙💜; Mega Storyia - cores Roxo, Starlight)
+•
+iPad Air M3 11 polegadas 128GB
+◦
+Média de Valores: R$4.066,67
+◦
+Preço mais alto registrado: R$4.300,00 (Mega Storyia - cores Azul, Lilás, Gray, Starlight)
+•
+iPad Air M3 11 polegadas 256GB
+◦
+Média de Valores: R$4.512,50
+◦
+Preço mais alto registrado: R$4.650,00 (Azur Impex - cores 💜💙💛🖤)
+•
+iPad Air M3 13 polegadas 128GB
+◦
+Média de Valores: R$5.380,00
+◦
+Preço mais alto registrado: R$5.800,00 (Mega Storyia - cor Gray)
+•
+iPad Air M3 13 polegadas 256GB
+◦
+Média de Valores: R$6.100,00
+◦
+Preço mais alto registrado: R$6.100,00 (Azur Impex - cores 💙🖤💛)
+•
+iPad Pro M4 11 polegadas 256GB
+◦
+Média de Valores: R$6.516,67
+◦
+Preço mais alto registrado: R$6.600,00 (Mega Storyia - cores Preto, Silver)
+•
+iPad Pro M4 13 polegadas 256GB
+◦
+Média de Valores: R$8.725,00
+◦
+Preço mais alto registrado: R$8.750,00 (Azur Impex - cor 🤍)
+•
+iPad Pro M4 13 polegadas 512GB
+◦
+Média de Valores: R$10.500,00
+◦
+Preço mais alto registrado: R$10.500,00 (Azur Impex - cor 🖤)
+III. MacBooks Lacrados
+•
+Mac Mini M4 16GB 512GB
+◦
+Média de Valores: R$5.925,00
+◦
+Preço mais alto registrado: R$6.100,00 (Azur Impex)
+•
+Mac Mini M4 Pro 24GB 512GB
+◦
+Média de Valores: R$10.200,00
+◦
+Preço mais alto registrado: R$10.200,00 (Azur Impex)
+•
+iMac M4 24 polegadas 16GB 256GB
+◦
+Média de Valores: R$10.562,50
+◦
+Preço mais alto registrado: R$11.350,00 (King Shop - cores SILVER, BLUE)
+•
+MacBook Air M1 13 polegadas 8GB 256GB
+◦
+Média de Valores: R$4.437,50
+◦
+Preço mais alto registrado: R$4.550,00 (Mega Storyia - cores Space gray, Silver, Rose/Gold)
+•
+MacBook Air M2 13 polegadas 8GB 256GB
+◦
+Média de Valores: R$5.683,33
+◦
+Preço mais alto registrado: R$5.700,00 (Azur Impex - cores 🤍🩶; Mega Storyia - cor Midnight)
+•
+MacBook Air M2 13 polegadas 8GB 512GB
+◦
+Média de Valores: R$5.800,00
+◦
+Preço mais alto registrado: R$5.800,00 (Azur Impex - cores 🤍🖤)
+•
+MacBook Air M2 13 polegadas 16GB 256GB
+◦
+Média de Valores: R$5.925,00
+◦
+Preço mais alto registrado: R$5.950,00 (Mega Storyia - cores Midnight, Starlight)
+•
+MacBook Air M3 13 polegadas 8GB 256GB
+◦
+Média de Valores: R$6.100,00
+◦
+Preço mais alto registrado: R$6.200,00 (Casimiro - cores Midnight, Starlight, Space Grey; Mega Storyia - cores Midnight, Starlight, Space gray)
+•
+MacBook Air M3 13 polegadas 8GB 512GB
+◦
+Média de Valores: R$6.300,00
+◦
+Preço mais alto registrado: R$6.300,00 (Azur Impex - cor 🖤)
+•
+MacBook Air M3 13 polegadas 16GB 256GB
+◦
+Média de Valores: R$6.425,00
+◦
+Preço mais alto registrado: R$6.450,00 (Azur Impex - cores 🩶🖤)
+•
+MacBook Air M3 13 polegadas 16GB 512GB
+◦
+Média de Valores: R$7.100,00
+◦
+Preço mais alto registrado: R$7.250,00 (Azur Impex - cores 🖤🤍💛)
+•
+MacBook Air M3 15 polegadas 8GB 512GB
+◦
+Média de Valores: R$9.100,00
+◦
+Preço mais alto registrado: R$9.200,00 (Mega Storyia - cores silver, Midnight, Starlight, SPACE)
+•
+MacBook Air M4 13 polegadas 16GB 256GB
+◦
+Média de Valores: R$6.550,00
+◦
+Preço mais alto registrado: R$6.650,00 (Mega Storyia - cores Azul, Midnight, Starlight)
+•
+MacBook Air M4 13 polegadas 16GB 512GB
+◦
+Média de Valores: R$8.737,50
+◦
+Preço mais alto registrado: R$9.500,00 (Mega Storyia - cores Starlight, Azul, Silver, Midnight)
+•
+MacBook Air M4 13 polegadas 24GB 512GB
+◦
+Média de Valores: R$9.450,00
+◦
+Preço mais alto registrado: R$9.700,00 (Mega Storyia - cores Midnight, Starlight, Azul, Silver)
+•
+MacBook Air M4 15 polegadas 16GB 256GB
+◦
+Média de Valores: R$8.950,00
+◦
+Preço mais alto registrado: R$9.600,00 (Mega Storyia - cores Azul, Starlight, Midnight, Silver)
+•
+MacBook Air M4 15 polegadas 16GB 512GB
+◦
+Média de Valores: R$10.200,00
+◦
+Preço mais alto registrado: R$10.200,00 (Azur Impex - cores 💙🖤)
+•
+MacBook Pro M3 Pro 14 polegadas 18GB 512GB
+◦
+Média de Valores: R$11.500,00
+◦
+Preço mais alto registrado: R$11.500,00 (Azur Impex - cor 🤍)
+•
+MacBook Pro M4 14 polegadas 16GB 512GB
+◦
+Média de Valores: R$10.850,00
+◦
+Preço mais alto registrado: R$11.300,00 (Mega Storyia - cores Space Black, Silver)
+•
+MacBook Pro M4 Pro 14 polegadas 24GB 512GB
+◦
+Média de Valores: R$13.800,00
+◦
+Preço mais alto registrado: R$14.700,00 (Mega Storyia - cores Silver, Black)
+•
+MacBook Pro M4 Pro 16 polegadas 24GB 512GB
+◦
+Média de Valores: R$16.600,00
+◦
+Preço mais alto registrado: R$16.800,00 (Casimiro - cor Space Black; Mega Storyia - cor Black)
+IV. Apple Watch Lacrados
+•
+Apple Watch SE 2 40MM GPS
+◦
+Média de Valores: R$1.377,50
+◦
+Preço mais alto registrado: R$1.450,00 (Azur Impex - cor 💛 STARLIGHT)
+•
+Apple Watch SE 2 40MM GPS + CEL
+◦
+Média de Valores: R$1.625,00
+◦
+Preço mais alto registrado: R$1.650,00 (Azur Impex - cores 🖤🤍💛)
+•
+Apple Watch SE 2 44MM GPS
+◦
+Média de Valores: R$1.545,00
+◦
+Preço mais alto registrado: R$1.650,00 (Azur Impex - cores 💛🤍🖤)
+•
+Apple Watch SE 2 44MM GPS + CEL
+◦
+Média de Valores: R$1.850,00
+◦
+Preço mais alto registrado: R$1.850,00 (Azur Impex - cores 💛🖤)
+•
+Apple Watch S10 42MM GPS
+◦
+Média de Valores: R$2.270,00
+◦
+Preço mais alto registrado: R$2.400,00 (Azur Impex - cor 💛 ROSE GOLD)
+•
+Apple Watch S10 46MM GPS
+◦
+Média de Valores: R$2.357,50
+◦
+Preço mais alto registrado: R$2.450,00 (Azur Impex - cor 🖤 BLACK)
+•
+Apple Watch Ultra 2 49MM GPS + CEL
+◦
+Média de Valores: R$5.166,67
+◦
+Preço mais alto registrado: R$5.200,00 (Mega Storyia - cor Preto/ Oceano Band Preto)
+V. AirPods Lacrados
+•
+AirPods 3
+◦
+Média de Valores: R$735,00
+◦
+Preço mais alto registrado: R$780,00 (Casimiro)
+•
+AirPods 4
+◦
+Média de Valores: R$845,00
+◦
+Preço mais alto registrado: R$900,00 (Azur Impex)
+•
+AirPods 4 (ANC)
+◦
+Média de Valores: R$1.250,00
+◦
+Preço mais alto registrado: R$1.300,00 (Azur Impex)
+•
+AirPods Pro 2
+◦
+Média de Valores: R$1.335,00
+◦
+Preço mais alto registrado: R$1.350,00 (Azur Impex; Mega Storyia - USB-C)
+•
+AirPods Max
+◦
+Média de Valores: R$3.450,00
+◦
+Preço mais alto registrado: R$3.700,00 (Mega Storyia - cor Midnight - USB-C 2024)
+VI. Apple Pencils Lacrados
+•
+Pencil Pro
+◦
+Média de Valores: R$802,50
+◦
+Preço mais alto registrado: R$850,00 (Azur Impex; Casimiro)
+•
+Pencil 2
+◦
+Média de Valores: R$610,00
+◦
+Preço mais alto registrado: R$680,00 (Azur Impex)
+•
+Pencil USB-C
+◦
+Média de Valores: R$687,50
+◦
+Preço mais alto registrado: R$800,00 (Azur Impex)
+VII. Teclados Lacrados
+•
+Magic Keyboard 11 polegadas (iPad M4)
+◦
+Média de Valores: R$2.500,00
+◦
+Preço mais alto registrado: R$2.500,00 (Azur Impex - cor 🖤)
+•
+Magic Keyboard 13 polegadas (iPad Air)
+◦
+Média de Valores: R$2.500,00
+◦
+Preço mais alto registrado: R$2.500,00 (Azur Impex - cor 🤍)
+•
+Magic Keyboard 13 polegadas (iPad Pro M4)
+◦
+Média de Valores: R$1.650,00
+◦
+Preço mais alto registrado: R$1.800,00 (Mega Storyia)
+•
+Magic Keyboard para iPad (iPad 10)
+◦
+Média de Valores: R$1.800,00
+◦
+Preço mais alto registrado: R$1.800,00 (Casimiro)
+•
+Smart Keyboard para iPad (iPad 9)
+◦
+Média de Valores: R$850,00
+◦
+Preço mais alto registrado: R$900,00 (Mega Storyia - cor Preto)
+VIII. Mouses Lacrados
+•
+Magic Mouse 3 (USB-C)
+◦
+Média de Valores: R$723,33
+◦
+Preço mais alto registrado: R$750,00 (Azur Impex - cor 🖤; Mega Storyia - cor Branco)
+•
+Magic Mouse 2
+◦
+Média de Valores: R$650,00
+◦
+Preço mais alto registrado: R$750,00 (Mega Storyia - cor Preto)
+IX. AirTag Lacrados
+•
+AirTag 1 Pack
+◦
+Média de Valores: R$230,00
+◦
+Preço mais alto registrado: R$240,00 (Azur Impex)
+•
+AirTag 4 Pack
+◦
+Média de Valores: R$610,00
+◦
+Preço mais alto registrado: R$650,00 (Azur Impex)
+X. Acessórios e Outros Produtos Adicionais (Lacrados e Originais Apple, se especificado)
+•
+Fonte Turbo USB-C Original Apple (20W)
+◦
+Média de Valores: R$130,00
+◦
+Preço mais alto registrado: R$130,00 (Mega Storyia; Montana Celulares)
+•
+Cabo USB-C para Lightning Original Apple
+◦
+Mega Storyia lista por R$120,00.
+◦
+Montana Celulares lista por R$50,00. Devido à diferença de preço significativa, essas listagens não foram incluídas na média, pois podem se referir a produtos com distinções na qualidade ou origem, apesar da designação "Original Apple".
+•
+Cabo USB-C para USB-C Original Apple (para iPhone 15)
+◦
+Mega Storyia lista por R$130,00.
+◦
+Montana Celulares lista por R$50,00. Pela mesma razão acima, não foram incluídos na média.

--- a/server/scripts/seedProducts.js
+++ b/server/scripts/seedProducts.js
@@ -1,0 +1,71 @@
+const sqlite3 = require('sqlite3').verbose();
+const { v4: uuidv4 } = require('uuid');
+const path = require('path');
+const fs = require('fs');
+
+const dbPath = path.resolve(__dirname, '../database.sqlite');
+const dataPath = path.resolve(__dirname, 'products_data.txt');
+
+const db = new sqlite3.Database(dbPath);
+
+const rawText = fs.readFileSync(dataPath, 'utf8');
+
+const categoryMap = {
+  'iPhones Lacrados': 'iPhone',
+  'iPads Lacrados': 'iPad',
+  'MacBooks Lacrados': 'MacBook Air',
+  'Apple Watch Lacrados': 'Apple Watch',
+  'AirPods Lacrados': 'AirPods',
+  'Apple Pencils Lacrados': 'Outros',
+  'Teclados Lacrados': 'Outros',
+  'Mouses Lacrados': 'Outros',
+  'AirTag Lacrados': 'Outros',
+  'Acessórios e Outros Produtos Adicionais (Lacrados e Originais Apple, se especificado)': 'Outros'
+};
+
+function parseProducts(text) {
+  const lines = text.split(/\n+/).map(l => l.trim()).filter(Boolean);
+  let currentCategory = '';
+  const products = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const catMatch = line.match(/^[IVX]+\.\s*(.*)$/);
+    if (catMatch) { currentCategory = catMatch[1]; continue; }
+    if (line.startsWith('•')) {
+      const name = line.slice(1).trim();
+      const avgLine = lines[i+2] && lines[i+1].includes('Média de Valores') ? lines[i+1] : null;
+      const highLine = lines[i+2] && lines[i+2].includes('Preço mais alto') ? lines[i+2] : null;
+      if (avgLine) {
+        const avgPriceMatch = avgLine.match(/R\$([\d.,]+)/);
+        const highPriceMatch = highLine ? highLine.match(/R\$([\d.,]+)/) : null;
+        const highInfo = highLine ? highLine.split(/R\$[\d.,]+\s*/)[1] || '' : '';
+        products.push({
+          name,
+          category: categoryMap[currentCategory] || 'Outros',
+          avgPrice: avgPriceMatch ? parseFloat(avgPriceMatch[1].replace('.', '').replace(',', '.')) : null,
+          highPrice: highPriceMatch ? parseFloat(highPriceMatch[1].replace('.', '').replace(',', '.')) : null,
+          highInfo: highInfo.trim()
+        });
+      }
+    }
+  }
+  return products;
+}
+
+const products = parseProducts(rawText);
+
+const userId = 'seed-user';
+const now = new Date().toISOString();
+
+console.log(`Parsed ${products.length} products.`);
+
+db.serialize(() => {
+  products.forEach(p => {
+    const id = uuidv4();
+    const data = JSON.stringify({ name: p.name, categoryId: p.category, valorTabela: p.avgPrice });
+    db.run('INSERT INTO productPricing (id, "userId", data, updatedAt) VALUES (?,?,?,?)', [id, userId, data, now]);
+  });
+});
+
+db.close();


### PR DESCRIPTION
## Summary
- add script and data to seed product pricing entries
- document how to seed sample product pricing in README

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68519dfb0dd8832299e585bf0dd85da2