### PR TITLE
Remove localStorage from pricing page

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -227,6 +227,23 @@ function initializeDatabase() {
         FOREIGN KEY ("userId") REFERENCES users(id)
     )`);
 
+    db.run(`CREATE TABLE IF NOT EXISTS productCategories (
+        id TEXT PRIMARY KEY,
+        "userId" TEXT NOT NULL,
+        name TEXT NOT NULL,
+        dustBag REAL NOT NULL,
+        packaging REAL NOT NULL,
+        FOREIGN KEY ("userId") REFERENCES users(id)
+    )`);
+
+    db.run(`CREATE TABLE IF NOT EXISTS productPricingGlobals (
+        "userId" TEXT PRIMARY KEY,
+        nfPercent REAL NOT NULL,
+        nfProduto REAL NOT NULL,
+        frete REAL NOT NULL,
+        FOREIGN KEY ("userId") REFERENCES users(id)
+    )`);
+
     db.run(`CREATE TABLE IF NOT EXISTS productPricing (
         id TEXT PRIMARY KEY,
         "userId" TEXT NOT NULL,

--- a/services/AppService.tsx
+++ b/services/AppService.tsx
@@ -7,7 +7,7 @@ import {
     OrderOccurrence, OccurrenceStatus, OccurrenceType,
     DEFAULT_BLU_FACILITA_ANNUAL_INTEREST_RATE as DEFAULT_BF_RATE_CONST,
     ClientPayment, User, HistoricalParsedProduct, CustomTableRow,
-    PricingProduct, PricingHistoryEntry
+    PricingProduct, PricingHistoryEntry, PricingCategory, PricingGlobals
 } from '../types'; // Updated User type
 import { v4 as uuidv4 } from 'uuid';
 // --- CONSTANTS ---
@@ -553,6 +553,30 @@ export const deletePricingProduct = async (id: string): Promise<void> => {
 export const getPricingHistory = async (productId?: string): Promise<PricingHistoryEntry[]> => {
     const endpoint = productId ? `/product-pricing/history?productId=${productId}` : '/product-pricing/history';
     return apiClient<PricingHistoryEntry[]>(endpoint);
+};
+
+// --- Product Category & Globals Services ---
+export const getProductCategories = async (): Promise<PricingCategory[]> => {
+    return apiClient<PricingCategory[]>('/product-pricing/categories');
+};
+
+export const saveProductCategory = async (cat: PricingCategory): Promise<PricingCategory> => {
+    if (cat.id) {
+        return apiClient<PricingCategory>(`/product-pricing/categories/${cat.id}`, { method: 'PUT', body: JSON.stringify(cat) });
+    }
+    return apiClient<PricingCategory>('/product-pricing/categories', { method: 'POST', body: JSON.stringify(cat) });
+};
+
+export const deleteProductCategory = async (id: string): Promise<void> => {
+    return apiClient<void>(`/product-pricing/categories/${id}`, { method: 'DELETE' });
+};
+
+export const getPricingGlobals = async (): Promise<PricingGlobals> => {
+    return apiClient<PricingGlobals>('/product-pricing/globals');
+};
+
+export const savePricingGlobals = async (g: PricingGlobals): Promise<PricingGlobals> => {
+    return apiClient<PricingGlobals>('/product-pricing/globals', { method: 'PUT', body: JSON.stringify(g) });
 };
 
 // --- Custom Table Services ---

--- a/types.ts
+++ b/types.ts
@@ -114,6 +114,19 @@ export interface PricingHistoryEntry {
   recordedAt: string;
 }
 
+export interface PricingCategory {
+  id: string;
+  name: string;
+  dustBag: number;
+  packaging: number;
+}
+
+export interface PricingGlobals {
+  nfPercent: number;
+  nfProduto: number;
+  frete: number;
+}
+
 
 export interface InternalNote {
     id: string;


### PR DESCRIPTION
## Summary
- add SQLite tables for product categories and pricing globals
- expose API routes for categories and globals
- persist pricing categories and defaults server-side
- update product pricing dashboard to sync via API

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6851e89b034883228b590c6076071b13