### PR TITLE
Add toggle to inherit profit from category

### DIFF
--- a/services/AppService.tsx
+++ b/services/AppService.tsx
@@ -536,7 +536,12 @@ export const deleteOrderCostItem = async (costItemId: string): Promise<void> => 
 
 // --- Product Pricing Services ---
 export const getPricingProducts = async (): Promise<PricingListItem[]> => {
-    return apiClient<PricingListItem[]>('/product-pricing');
+    return apiClient<PricingListItem[]>('/product-pricing').then(data =>
+        data.map(it => ({
+            usarLucroDaCategoria: it.usarLucroDaCategoria ?? true,
+            ...it,
+        }))
+    );
 };
 
 export const savePricingProduct = async (product: PricingProduct): Promise<PricingProduct> => {

--- a/types.ts
+++ b/types.ts
@@ -97,6 +97,7 @@ export interface PricingProduct {
   frete: number;
   valorTabela: number;
   lucroPercent: number;
+  usarLucroDaCategoria?: boolean;
   caixa: string;
   freteDeclarado?: number;
   freteEuaBr?: number;
@@ -452,5 +453,6 @@ export interface PricingListItem {
   custoBRL: number | null;
   valorTabela: number | null;
   lucroPercent?: number | null;
+  usarLucroDaCategoria?: boolean;
   updatedAt?: string;
 }


### PR DESCRIPTION
## Summary
- support `usarLucroDaCategoria` field in Pricing types
- default the property when fetching pricing data
- update product pricing dashboard
  - allow following category margin with a checkbox
  - recompute prices only when appropriate

## Testing
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68520ff2e9e0832292e11be3027d04e0