### PR TITLE
Fix order form step navigation

### DIFF
--- a/features/OrdersFeature.tsx
+++ b/features/OrdersFeature.tsx
@@ -631,7 +631,16 @@ Observações: O valor desta nota fiscal refere-se exclusivamente ao serviço de
             <div className="flex space-x-3 ml-auto">
                 <Button type="button" variant="secondary" onClick={onClose} disabled={isLoading}>Cancelar</Button>
                 {currentStep < FORM_STEPS.length - 1 ? (
-                    <Button type="button" onClick={() => dispatch({ type: 'NEXT_STEP' })} disabled={isLoading}>Próximo</Button>
+                    <Button
+                      type="button"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        dispatch({ type: 'NEXT_STEP' });
+                      }}
+                      disabled={isLoading}
+                    >
+                      Próximo
+                    </Button>
                 ) : (
                     <Button type="submit" isLoading={isLoading} disabled={isLoading}>{initialOrder ? 'Salvar Alterações' : 'Adicionar Encomenda'}</Button>
                 )}


### PR DESCRIPTION
## Summary
- prevent premature form submission when clicking `Próximo` in order edit modal

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6852f231d0648322919854d5fe1d2d6d