### PR TITLE
Fix timeline status completion

### DIFF
--- a/features/OrderDetailsPage.tsx
+++ b/features/OrderDetailsPage.tsx
@@ -341,7 +341,7 @@ const OrderDetailsPage: React.FC = () => {
         {relevantStatuses.map((status, index) => {
           const historyEntry = getStatusHistory(status);
           const isCurrentActualStatus = order.status === status;
-          const isPastStatus = historyEntry && ORDER_STATUS_OPTIONS.indexOf(status) < ORDER_STATUS_OPTIONS.indexOf(order.status);
+          const isPastStatus = ORDER_STATUS_OPTIONS.indexOf(status) < ORDER_STATUS_OPTIONS.indexOf(order.status);
           return (
             <div key={status} className="flex items-start">
               <div className="flex flex-col items-center mr-3">

--- a/features/OrdersFeature.tsx
+++ b/features/OrdersFeature.tsx
@@ -168,7 +168,7 @@ const OrderStatusTimeline: React.FC<{ order: Order }> = ({ order }) => {
       {relevantStatuses.map((status, index) => {
         const historyEntry = getStatusHistory(status);
         const isCurrentActualStatus = order.status === status;
-        const isPastStatus = historyEntry && ORDER_STATUS_OPTIONS.indexOf(status) < ORDER_STATUS_OPTIONS.indexOf(order.status);
+        const isPastStatus = ORDER_STATUS_OPTIONS.indexOf(status) < ORDER_STATUS_OPTIONS.indexOf(order.status);
 
         return (
           <div key={status} className="flex items-start">


### PR DESCRIPTION
## Summary
- show earlier statuses as completed when skipping ahead in order timeline

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68534cdeb0008322a92da6681b6a629c