### PR TITLE
Add configurable price rounding

### DIFF
--- a/features/ProductPricingDashboard.tsx
+++ b/features/ProductPricingDashboard.tsx
@@ -28,7 +28,7 @@ const ProductPricingDashboardPage: React.FC = () => {
   const [historyFor, setHistoryFor] = useState<number | null>(null);
   const [historyEntries, setHistoryEntries] = useState<PricingHistoryEntry[]>([]);
   const [categories, setCategories] = useState<PricingCategory[]>([]);
-  const [globals, setGlobals] = useState<PricingGlobals>({ nfPercent: 0, nfProduto: 0, frete: 0 });
+  const [globals, setGlobals] = useState<PricingGlobals>({ nfPercent: 0, nfProduto: 0, frete: 0, roundTo: 70 });
   const [savingGlobals, setSavingGlobals] = useState(false);
   const [highlightGlobals, setHighlightGlobals] = useState(false);
   const [highlightProductId, setHighlightProductId] = useState<number | null>(null);
@@ -74,7 +74,12 @@ const ProductPricingDashboardPage: React.FC = () => {
       (globals.nfProduto || 0) +
       (globals.frete || 0);
     const withNf = base * (1 + (globals.nfPercent || 0));
-    return withNf * (1 + profit / 100);
+    const raw = withNf * (1 + profit / 100);
+    const r = globals.roundTo ?? 70;
+    const lower = Math.floor(raw / 100) * 100 + r;
+    const higher = Math.ceil(raw / 100) * 100 + r;
+    const rounded = Math.abs(raw - lower) <= Math.abs(higher - raw) ? lower : higher;
+    return Math.round(rounded);
   };
 
   const loadHistory = useCallback((id: number) => {
@@ -528,7 +533,7 @@ const ProductPricingDashboardPage: React.FC = () => {
         ))}
       </Card>
       <Card title="Configurações Globais" bodyClassName="p-4 space-y-2" className={highlightGlobals ? 'border-green-500' : ''}>
-        <div className="grid grid-cols-3 gap-4">
+        <div className="grid grid-cols-4 gap-4">
           <Input
             id="nfPercent"
             label="NF %"
@@ -554,6 +559,15 @@ const ProductPricingDashboardPage: React.FC = () => {
             step="0.01"
             value={globals.frete}
             onChange={e => setGlobals({ ...globals, frete: parseFloat(e.target.value) || 0 })}
+            onBlur={() => saveGlobals(globals)}
+          />
+          <Input
+            id="roundTo"
+            label="Arredondar p/"
+            type="number"
+            step="1"
+            value={globals.roundTo}
+            onChange={e => setGlobals({ ...globals, roundTo: parseFloat(e.target.value) || 0 })}
             onBlur={() => saveGlobals(globals)}
           />
         </div>

--- a/server/database.js
+++ b/server/database.js
@@ -279,6 +279,7 @@ function initializeDatabase() {
         nfPercent REAL NOT NULL,
         nfProduto REAL NOT NULL,
         frete REAL NOT NULL,
+        roundTo REAL NOT NULL DEFAULT 70,
         FOREIGN KEY ("userId") REFERENCES users(id)
     )`);
 

--- a/server/server.js
+++ b/server/server.js
@@ -1131,27 +1131,32 @@ app.delete('/api/product-pricing/categories/:id', authenticateToken, (req, res) 
 
 // Pricing Globals
 app.get('/api/product-pricing/globals', authenticateToken, (req, res) => {
-    db.get('SELECT nfPercent, nfProduto, frete FROM productPricingGlobals WHERE "userId" = $1', [req.user.id], (err, row) => {
+    db.get('SELECT nfPercent, nfProduto, frete, roundTo FROM productPricingGlobals WHERE "userId" = $1', [req.user.id], (err, row) => {
         if (err) {
             console.error('Error fetching globals:', err.message);
             return res.status(500).json({ message: 'Failed to fetch globals.' });
         }
         if (!row) {
-            return res.json({ nfPercent: 0.02, nfProduto: 30, frete: 105 });
+            return res.json({ nfPercent: 0.02, nfProduto: 30, frete: 105, roundTo: 70 });
         }
-        res.json(row);
+        res.json({
+            nfPercent: row.nfPercent,
+            nfProduto: row.nfProduto,
+            frete: row.frete,
+            roundTo: row.roundTo ?? 70
+        });
     });
 });
 
 app.put('/api/product-pricing/globals', authenticateToken, (req, res) => {
-    const { nfPercent, nfProduto, frete } = req.body;
-    const sql = 'INSERT INTO productPricingGlobals ("userId", nfPercent, nfProduto, frete) VALUES ($1,$2,$3,$4) ON CONFLICT("userId") DO UPDATE SET nfPercent=$2, nfProduto=$3, frete=$4';
-    db.run(sql, [req.user.id, nfPercent, nfProduto, frete], function(err) {
+    const { nfPercent, nfProduto, frete, roundTo } = req.body;
+    const sql = 'INSERT INTO productPricingGlobals ("userId", nfPercent, nfProduto, frete, roundTo) VALUES ($1,$2,$3,$4,$5) ON CONFLICT("userId") DO UPDATE SET nfPercent=$2, nfProduto=$3, frete=$4, roundTo=$5';
+    db.run(sql, [req.user.id, nfPercent, nfProduto, frete, roundTo], function(err) {
         if (err) {
             console.error('Error saving globals:', err.message);
             return res.status(500).json({ message: 'Failed to save globals.' });
         }
-        res.json({ nfPercent, nfProduto, frete });
+        res.json({ nfPercent, nfProduto, frete, roundTo });
     });
 });
 

--- a/types.ts
+++ b/types.ts
@@ -127,6 +127,7 @@ export interface PricingGlobals {
   nfPercent: number;
   nfProduto: number;
   frete: number;
+  roundTo: number;
 }
 
 


### PR DESCRIPTION
## Summary
- add `roundTo` column in productPricingGlobals table
- expose new `roundTo` field via pricing globals API
- update types and dashboard UI to edit rounding value
- round computed product prices using the configured value

## Testing
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68534dcdb7988322a12ee035e3755181