### PR TITLE
Add SaaS client admin page

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,6 +18,7 @@ import { TradeInEvaluationPage } from './features/TradeInEvaluationFeature';
 import { FinancialReportsPageContainer } from './features/FinancialReportsFeature';
 import { UserManagementPage } from './features/UserManagementFeature';
 import ProductPricingDashboardPage from './features/ProductPricingDashboard';
+import SaaSClientsAdminPage from './features/SaaSClientsAdminFeature';
 import { PageTitle, Card, Tabs, Tab, ResponsiveTable, Spinner, Button, Modal, Select as SharedSelect, Alert, Input as SharedInput, Textarea as SharedTextarea } from './components/SharedComponents';
 import RemindersWidget from './components/RemindersWidget';
 import PendingOrdersWidget from './components/PendingOrdersWidget';
@@ -69,6 +70,7 @@ const NAV_ITEMS: NavItemWithExact[] = [
   { name: 'Calculadora Venda', path: '/sale-calculator', icon: Calculator },
   { name: 'Avaliação de Troca', path: '/trade-in-evaluation', icon: Calculator },
   { name: 'Usuários', path: '/user-management', icon: Users, adminOnly: true },
+  { name: 'Clientes SAAS', path: '/manage-clients', icon: Cog6ToothIcon, adminOnly: true },
 ];
 
 // --- Modals (AddOrderCostModal, RegisterPaymentModal) ---
@@ -457,6 +459,7 @@ const App: React.FC<{}> = () => {
                     <Route path="/product-pricing" element={<ProductPricingDashboardPage />} />
                     <Route path="/financial-reports" element={<FinancialReportsPageContainer />} />
                     <Route path="/user-management" element={<UserManagementPage />} />
+                    <Route path="/manage-clients" element={<SaaSClientsAdminPage />} />
                     <Route path="*" element={<Navigate to="/" replace />} />
                   </Routes>
                 </DashboardLayout>

--- a/features/SaaSClientsAdminFeature.tsx
+++ b/features/SaaSClientsAdminFeature.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import { SaaSClient } from '../types';
+import { getSaaSClients, formatDateBR } from '../services/AppService';
+import { PageTitle, Card, ResponsiveTable, Spinner, Alert } from '../components/SharedComponents';
+
+const SaaSClientsAdminPage: React.FC = () => {
+  const [clients, setClients] = useState<SaaSClient[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await getSaaSClients();
+        setClients(data);
+      } catch (err: any) {
+        setError('Falha ao carregar clientes.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const columns = [
+    { header: 'Organização', accessor: (c: SaaSClient) => c.organizationName },
+    { header: 'E-mail', accessor: (c: SaaSClient) => c.contactEmail },
+    { header: 'Plano', accessor: (c: SaaSClient) => c.subscriptionPlan },
+    { header: 'Status', accessor: (c: SaaSClient) => c.subscriptionStatus },
+    { header: 'Cadastro', accessor: (c: SaaSClient) => formatDateBR(c.signupDate, true) },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <PageTitle title="Clientes do SAAS" subtitle="Gerencie organizações assinantes" />
+      <Card>
+        {isLoading ? (
+          <Spinner />
+        ) : error ? (
+          <Alert type="error" message={error} onClose={() => setError(null)} />
+        ) : (
+          <ResponsiveTable columns={columns} data={clients} rowKeyAccessor="id" />
+        )}
+      </Card>
+    </div>
+  );
+};
+
+export default SaaSClientsAdminPage;

--- a/services/AppService.tsx
+++ b/services/AppService.tsx
@@ -7,7 +7,8 @@ import {
     OrderOccurrence, OccurrenceStatus, OccurrenceType,
     DEFAULT_BLU_FACILITA_ANNUAL_INTEREST_RATE as DEFAULT_BF_RATE_CONST,
     ClientPayment, User, HistoricalParsedProduct, CustomTableRow,
-    PricingProduct, PricingHistoryEntry, PricingCategory, PricingGlobals, PricingListItem
+    PricingProduct, PricingHistoryEntry, PricingCategory, PricingGlobals, PricingListItem,
+    SaaSClient
 } from '../types'; // Updated User type
 import { v4 as uuidv4 } from 'uuid';
 // --- CONSTANTS ---
@@ -645,6 +646,22 @@ export const inviteUser = async (data: { email: string; password: string; name?:
 
 export const updateUserRole = async (userId: string, role: string): Promise<User> => {
     return apiClient<User>(`/users/${userId}/role`, { method: 'PUT', body: JSON.stringify({ role }) });
+};
+
+// --- SaaS Clients Management ---
+export const getSaaSClients = async (): Promise<SaaSClient[]> => {
+    return apiClient<SaaSClient[]>('/saas/clients');
+};
+
+export const saveSaaSClient = async (client: Omit<SaaSClient, 'id'> | SaaSClient): Promise<SaaSClient> => {
+    if ('id' in client && client.id) {
+        return apiClient<SaaSClient>(`/saas/clients/${client.id}`, { method: 'PUT', body: JSON.stringify(client) });
+    }
+    return apiClient<SaaSClient>('/saas/clients', { method: 'POST', body: JSON.stringify(client) });
+};
+
+export const deleteSaaSClient = async (id: string): Promise<void> => {
+    return apiClient<void>(`/saas/clients/${id}`, { method: 'DELETE' });
 };
 
 // CREDIT_CARD_RATES_CONFIG and calculateCreditCardFees can remain client-side as they are pure utility functions.

--- a/types.ts
+++ b/types.ts
@@ -278,6 +278,15 @@ export interface Organization {
   name: string;
 }
 
+export interface SaaSClient {
+  id: string;
+  organizationName: string;
+  contactEmail: string;
+  subscriptionPlan: string;
+  subscriptionStatus: 'active' | 'trial' | 'canceled';
+  signupDate: string; // ISO date string
+}
+
 export interface NavItem {
   name: string;
   path: string;


### PR DESCRIPTION
## Summary
- define `SaaSClient` type
- expose SaaS client CRUD functions in `AppService`
- create `SaaSClientsAdminFeature` page to list SAAS clients
- add navigation link and route for the new page

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68597663424083228cdfcdf2dadcceee