### PR TITLE
Implement admin login and route guard

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, ReactNode, useEffect, useCallback } from 'react';
 import { HashRouter, Routes, Route, Link, useLocation, Navigate, useNavigate } from 'react-router-dom';
-import { AuthProvider, LoginPage, AuthGuard, useAuth } from './Auth';
+import { AuthProvider, LoginPage, AdminLoginPage, AuthGuard, AdminGuard, useAuth } from './Auth';
 import { OrdersPage } from './features/OrdersFeature';
 import OrderDetailsPage from './features/OrderDetailsPage';
 import OrderEditPage from './features/OrderEditPage';
@@ -437,6 +437,7 @@ const App: React.FC<{}> = () => {
       <HashRouter>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
+          <Route path="/admin-login" element={<AdminLoginPage />} />
           <Route
             path="/*"
             element={
@@ -458,8 +459,8 @@ const App: React.FC<{}> = () => {
                     <Route path="/trade-in-evaluation" element={<TradeInEvaluationPage />} />
                     <Route path="/product-pricing" element={<ProductPricingDashboardPage />} />
                     <Route path="/financial-reports" element={<FinancialReportsPageContainer />} />
-                    <Route path="/user-management" element={<UserManagementPage />} />
-                    <Route path="/manage-clients" element={<SaaSClientsAdminPage />} />
+                    <Route path="/user-management" element={<AdminGuard><UserManagementPage /></AdminGuard>} />
+                    <Route path="/manage-clients" element={<AdminGuard><SaaSClientsAdminPage /></AdminGuard>} />
                     <Route path="*" element={<Navigate to="/" replace />} />
                   </Routes>
                 </DashboardLayout>

--- a/services/AppService.tsx
+++ b/services/AppService.tsx
@@ -13,6 +13,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 // --- CONSTANTS ---
 export const APP_NAME = "Blu Imports Dashboard";
+export const ADMIN_APP_NAME = "Blu Imports SaaS Admin";
 // API_KEY is no longer client-side
 
 export const ORDER_STATUS_OPTIONS: OrderStatus[] = Object.values(OrderStatus);


### PR DESCRIPTION
## Summary
- add `ADMIN_APP_NAME` constant
- update `LoginPage` to support admin mode
- introduce `AdminLoginPage` and `AdminGuard`
- protect admin routes and add `/admin-login` path

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685978792e5c8322939a149129c0e058