### PR TITLE
Fix SaaS clients table crash

### DIFF
--- a/services/AppService.tsx
+++ b/services/AppService.tsx
@@ -651,7 +651,8 @@ export const updateUserRole = async (userId: string, role: string): Promise<User
 
 // --- SaaS Clients Management ---
 export const getSaaSClients = async (): Promise<SaaSClient[]> => {
-    return apiClient<SaaSClient[]>('/saas/clients');
+    const data = await apiClient<SaaSClient[] | undefined>('/saas/clients');
+    return Array.isArray(data) ? data : [];
 };
 
 export const saveSaaSClient = async (client: Omit<SaaSClient, 'id'> | SaaSClient): Promise<SaaSClient> => {


### PR DESCRIPTION
## Summary
- handle when `/saas/clients` API returns no data

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68597a7f4da083229c346d790c9cb6d3