### PR TITLE
Add basic admin login

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -19,6 +19,7 @@ import { FinancialReportsPageContainer } from './features/FinancialReportsFeatur
 import { UserManagementPage } from './features/UserManagementFeature';
 import ProductPricingDashboardPage from './features/ProductPricingDashboard';
 import SaaSClientsAdminPage from './features/SaaSClientsAdminFeature';
+import AdminHomePage from './features/AdminHomeFeature';
 import { PageTitle, Card, Tabs, Tab, ResponsiveTable, Spinner, Button, Modal, Select as SharedSelect, Alert, Input as SharedInput, Textarea as SharedTextarea } from './components/SharedComponents';
 import RemindersWidget from './components/RemindersWidget';
 import PendingOrdersWidget from './components/PendingOrdersWidget';
@@ -459,6 +460,7 @@ const App: React.FC<{}> = () => {
                     <Route path="/trade-in-evaluation" element={<TradeInEvaluationPage />} />
                     <Route path="/product-pricing" element={<ProductPricingDashboardPage />} />
                     <Route path="/financial-reports" element={<FinancialReportsPageContainer />} />
+                    <Route path="/admin" element={<AdminGuard><AdminHomePage /></AdminGuard>} />
                     <Route path="/user-management" element={<AdminGuard><UserManagementPage /></AdminGuard>} />
                     <Route path="/manage-clients" element={<AdminGuard><SaaSClientsAdminPage /></AdminGuard>} />
                     <Route path="*" element={<Navigate to="/" replace />} />

--- a/Auth.tsx
+++ b/Auth.tsx
@@ -4,8 +4,6 @@ import { AuthContextType, User } from './types';
 import { APP_NAME, ADMIN_APP_NAME } from './services/AppService';
 import { Button, Card, PageTitle, Alert, Spinner, Input } from './components/SharedComponents';
 
-const ADMIN_FIXED_EMAIL = 'arthur@centralmaker.com';
-const ADMIN_FIXED_PASSWORD = 'admin123';
 
 async function apiLogin(email: string, password: string): Promise<{ token: string; user: User }> {
   const response = await fetch('/api/auth/login', {
@@ -94,21 +92,6 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     setIsAuthLoading(true);
     setAuthError(null);
     try {
-      if (email === ADMIN_FIXED_EMAIL && password === ADMIN_FIXED_PASSWORD) {
-        const user: User = {
-          id: 'admin-fixed',
-          email: ADMIN_FIXED_EMAIL,
-          name: 'Admin',
-          role: 'admin',
-          organizationId: 'admin',
-          registrationDate: new Date().toISOString(),
-        };
-        const token = 'admin-fixed-token';
-        localStorage.setItem('authToken', token);
-        localStorage.setItem('authUser', JSON.stringify(user));
-        setCurrentUser(user);
-        return user;
-      }
       const { token, user } = await apiLogin(email, password);
       localStorage.setItem('authToken', token);
       localStorage.setItem('authUser', JSON.stringify(user));

--- a/Auth.tsx
+++ b/Auth.tsx
@@ -4,6 +4,9 @@ import { AuthContextType, User } from './types';
 import { APP_NAME, ADMIN_APP_NAME } from './services/AppService';
 import { Button, Card, PageTitle, Alert, Spinner, Input } from './components/SharedComponents';
 
+const ADMIN_FIXED_EMAIL = 'arthur@centralmaker.com';
+const ADMIN_FIXED_PASSWORD = 'admin123';
+
 async function apiLogin(email: string, password: string): Promise<{ token: string; user: User }> {
   const response = await fetch('/api/auth/login', {
     method: 'POST',
@@ -91,6 +94,21 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     setIsAuthLoading(true);
     setAuthError(null);
     try {
+      if (email === ADMIN_FIXED_EMAIL && password === ADMIN_FIXED_PASSWORD) {
+        const user: User = {
+          id: 'admin-fixed',
+          email: ADMIN_FIXED_EMAIL,
+          name: 'Admin',
+          role: 'admin',
+          organizationId: 'admin',
+          registrationDate: new Date().toISOString(),
+        };
+        const token = 'admin-fixed-token';
+        localStorage.setItem('authToken', token);
+        localStorage.setItem('authUser', JSON.stringify(user));
+        setCurrentUser(user);
+        return user;
+      }
       const { token, user } = await apiLogin(email, password);
       localStorage.setItem('authToken', token);
       localStorage.setItem('authUser', JSON.stringify(user));

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Follow the steps below in order:
    npm run init-db            # creates tables
    npm run seed-products      # populate productPricing
    npm run assign-orgid       # fill organizationId in legacy data
+   npm run create-admin       # add default admin account
    cd ..
    ```
 

--- a/features/AdminHomeFeature.tsx
+++ b/features/AdminHomeFeature.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { PageTitle, Card } from '../components/SharedComponents';
+
+const AdminHomePage: React.FC = () => (
+  <div className="space-y-4">
+    <PageTitle title="Painel Admin" subtitle="Acesso restrito" />
+    <Card>
+      <p>Bem-vindo à área administrativa.</p>
+    </Card>
+  </div>
+);
+
+export default AdminHomePage;

--- a/features/AdminHomeFeature.tsx
+++ b/features/AdminHomeFeature.tsx
@@ -1,13 +1,103 @@
-import React from 'react';
-import { PageTitle, Card } from '../components/SharedComponents';
+import React, { useEffect, useState } from 'react';
+import { PageTitle, Card, Spinner } from '../components/SharedComponents';
 
-const AdminHomePage: React.FC = () => (
-  <div className="space-y-4">
-    <PageTitle title="Painel Admin" subtitle="Acesso restrito" />
-    <Card>
-      <p>Bem-vindo à área administrativa.</p>
+interface AdminSummary {
+  activeOrganizations: number;
+  ongoingOrders: number;
+  totalRevenue: number;
+}
+
+const AdminHomePage: React.FC = () => {
+  const [summary, setSummary] = useState<AdminSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch('/api/admin/summary', { credentials: 'include' })
+      .then(res => res.json())
+      .then(data => setSummary(data))
+      .catch(err => {
+        console.error('Failed to load admin summary', err);
+        setSummary(null);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  const MetricCard: React.FC<{ label: string; value: React.ReactNode }> = ({ label, value }) => (
+    <Card className="p-4 flex flex-col items-center justify-center text-center">
+      <p className="text-sm text-gray-500">{label}</p>
+      <p className="text-2xl font-semibold text-gray-800 mt-1">{value}</p>
     </Card>
-  </div>
-);
+  );
+
+  return (
+    <div className="space-y-6">
+      <PageTitle title="Painel Administrativo" subtitle="Visão geral do sistema" />
+      {loading && <Spinner />}
+      {summary && (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <MetricCard label="Empresas Ativas" value={summary.activeOrganizations} />
+          <MetricCard label="Pedidos em Andamento" value={summary.ongoingOrders} />
+          <MetricCard label="Faturamento Total Estimado" value={`R$ ${summary.totalRevenue.toFixed(2)}`} />
+        </div>
+      )}
+
+      <Card>
+        <h2 className="text-lg font-semibold mb-2">Notificações de Pendências</h2>
+        <p className="text-gray-600 text-sm">Pedidos sem nota fiscal, sem contrato ou pagamentos pendentes.</p>
+      </Card>
+
+      <Card>
+        <h2 className="text-lg font-semibold mb-2">Logs Recentes</h2>
+        <p className="text-gray-600 text-sm">Últimas ações dos usuários e falhas de API.</p>
+      </Card>
+
+      <Card>
+        <h2 className="text-lg font-semibold mb-2">Gestão de Usuários / Clientes</h2>
+        <p className="text-gray-600 text-sm">Administre contas de empresas e usuários.</p>
+      </Card>
+
+      <Card>
+        <h2 className="text-lg font-semibold mb-2">Planos e Faturamento</h2>
+        <p className="text-gray-600 text-sm">Configuração de planos e acompanhamento de pagamentos.</p>
+      </Card>
+
+      <Card>
+        <h2 className="text-lg font-semibold mb-2">Gestão de Pedidos (Global)</h2>
+        <p className="text-gray-600 text-sm">Acesso a todos os pedidos do sistema com filtros avançados.</p>
+      </Card>
+
+      <Card>
+        <h2 className="text-lg font-semibold mb-2">Gestão de Produtos / Modelos</h2>
+        <p className="text-gray-600 text-sm">Cadastro global de modelos e atualização em massa.</p>
+      </Card>
+
+      <Card>
+        <h2 className="text-lg font-semibold mb-2">Relatórios</h2>
+        <p className="text-gray-600 text-sm">Relatórios globais e exportação em PDF/CSV.</p>
+      </Card>
+
+      <Card>
+        <h2 className="text-lg font-semibold mb-2">IA / Automatizações</h2>
+        <p className="text-gray-600 text-sm">Configuração e acompanhamento de IAs disponíveis.</p>
+      </Card>
+
+      <Card>
+        <h2 className="text-lg font-semibold mb-2">Blu Labs / Produtos Experimentais</h2>
+        <p className="text-gray-600 text-sm">Envio de novos produtos para beta testers e acompanhamento.</p>
+      </Card>
+
+      <Card>
+        <h2 className="text-lg font-semibold mb-2">Configurações Avançadas</h2>
+        <p className="text-gray-600 text-sm">Textos padrão, integrações externas e parâmetros do sistema.</p>
+      </Card>
+
+      <Card>
+        <h2 className="text-lg font-semibold mb-2">Auditoria e Logs</h2>
+        <p className="text-gray-600 text-sm">Logs completos e exportação cronológica.</p>
+      </Card>
+    </div>
+  );
+};
 
 export default AdminHomePage;

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,8 @@
     "dev": "nodemon server.js",
     "init-db": "node database.js",
     "seed-products": "node scripts/seedProducts.js",
-    "assign-orgid": "node scripts/assignBluImportsOrgId.js"
+    "assign-orgid": "node scripts/assignBluImportsOrgId.js",
+    "create-admin": "node scripts/createAdminUser.js"
   },
   "keywords": [
     "express",

--- a/server/scripts/createAdminUser.js
+++ b/server/scripts/createAdminUser.js
@@ -1,0 +1,64 @@
+const sqlite3 = require('sqlite3').verbose();
+const bcrypt = require('bcryptjs');
+const { v4: uuidv4 } = require('uuid');
+const path = require('path');
+
+const dbPath = path.resolve(__dirname, '../database.sqlite');
+const db = new sqlite3.Database(dbPath);
+
+const EMAIL = 'arthur@centralmaker.com';
+const PASSWORD = 'admin123';
+const NAME = 'Admin';
+const ORG_NAME = 'Admin Org';
+
+const hashedPassword = bcrypt.hashSync(PASSWORD, 8);
+const userId = uuidv4();
+const orgId = uuidv4();
+
+function close() {
+  db.close();
+}
+
+db.serialize(() => {
+  db.get('SELECT id FROM organizations WHERE name = ?', [ORG_NAME], (err, row) => {
+    if (err) {
+      console.error('Error checking organization:', err.message);
+      return close();
+    }
+    const existingOrgId = row ? row.id : orgId;
+    const createUser = () => {
+      db.get('SELECT id FROM users WHERE email = ?', [EMAIL], (err2, userRow) => {
+        if (err2) {
+          console.error('Error checking existing admin:', err2.message);
+          return close();
+        }
+        if (userRow) {
+          console.log('Admin user already exists.');
+          return close();
+        }
+        const sql = 'INSERT INTO users (id, email, password, name, role, "registrationDate", "organizationId") VALUES (?,?,?,?,?,?,?)';
+        db.run(sql, [userId, EMAIL, hashedPassword, NAME, 'admin', new Date().toISOString(), existingOrgId], err3 => {
+          if (err3) {
+            console.error('Error inserting admin user:', err3.message);
+          } else {
+            console.log('Admin user created with id:', userId);
+          }
+          close();
+        });
+      });
+    };
+
+    if (row) {
+      createUser();
+    } else {
+      db.run('INSERT INTO organizations (id, name) VALUES (?,?)', [existingOrgId, ORG_NAME], err4 => {
+        if (err4) {
+          console.error('Error creating admin organization:', err4.message);
+          return close();
+        }
+        console.log('Organization created with id:', existingOrgId);
+        createUser();
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- support hardcoded admin login in `Auth.tsx`
- add `/admin` route with placeholder admin home page

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68597b8c437883228b9659fbd324d02d