### PR TITLE
Integrate SaaS clients with billing data

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,7 +18,6 @@ import { TradeInEvaluationPage } from './features/TradeInEvaluationFeature';
 import { FinancialReportsPageContainer } from './features/FinancialReportsFeature';
 import { UserManagementPage } from './features/UserManagementFeature';
 import ProductPricingDashboardPage from './features/ProductPricingDashboard';
-import AdminCompanyUsersPage from './features/AdminCompanyUsersFeature';
 import AdminHomePage from './features/AdminHomeFeature';
 import AdminBillingPage from './features/AdminBillingFeature';
 import AdminOrdersPage from './features/AdminOrdersFeature';
@@ -28,6 +27,7 @@ import AdminAIPage from './features/AdminAIFeature';
 import AdminBluLabsPage from './features/AdminBluLabsFeature';
 import AdminSettingsPage from './features/AdminAdvancedSettingsFeature';
 import AdminAuditLogsPage from './features/AdminAuditLogsFeature';
+import SaaSClientsAdminPage from './features/SaaSClientsAdminFeature';
 import { PageTitle, Card, Tabs, Tab, ResponsiveTable, Spinner, Button, Modal, Select as SharedSelect, Alert, Input as SharedInput, Textarea as SharedTextarea } from './components/SharedComponents';
 import RemindersWidget from './components/RemindersWidget';
 import PendingOrdersWidget from './components/PendingOrdersWidget';
@@ -89,6 +89,7 @@ const NAV_ITEMS: NavItemWithExact[] = [
 const ADMIN_NAV_ITEMS: NavItemWithExact[] = [
   { name: 'Dashboard', path: '/admin', icon: Home, exact: true },
   { name: 'Usuários/Clientes', path: '/admin/users', icon: Users },
+  { name: 'Clientes SaaS', path: '/admin/clients', icon: Users },
   { name: 'Planos e Faturamento', path: '/admin/billing', icon: BadgeDollarSign },
   { name: 'Pedidos', path: '/admin/orders', icon: ShoppingBag },
   { name: 'Produtos/Modelos', path: '/admin/products', icon: Package },
@@ -527,7 +528,7 @@ const App: React.FC<{}> = () => {
           <Route path="/admin/*" element={<AdminGuard><AdminLayout /></AdminGuard>}>
             <Route index element={<AdminHomePage />} />
             <Route path="users" element={<UserManagementPage />} />
-            <Route path="clients" element={<AdminCompanyUsersPage />} />
+            <Route path="clients" element={<SaaSClientsAdminPage />} />
             <Route path="billing" element={<AdminBillingPage />} />
             <Route path="orders" element={<AdminOrdersPage />} />
             <Route path="products" element={<AdminProductsPage />} />

--- a/features/SaaSClientsAdminFeature.tsx
+++ b/features/SaaSClientsAdminFeature.tsx
@@ -25,8 +25,9 @@ const SaaSClientsAdminPage: React.FC = () => {
   const columns = [
     { header: 'Organização', accessor: (c: SaaSClient) => c.organizationName },
     { header: 'E-mail', accessor: (c: SaaSClient) => c.contactEmail },
-    { header: 'Plano', accessor: (c: SaaSClient) => c.subscriptionPlan },
-    { header: 'Status', accessor: (c: SaaSClient) => c.subscriptionStatus },
+    { header: 'Plano', accessor: (c: SaaSClient) => c.billingPlanName || c.subscriptionPlan },
+    { header: 'Status', accessor: (c: SaaSClient) => c.billingStatus || c.subscriptionStatus },
+    { header: 'Próximo Venc.', accessor: (c: SaaSClient) => c.nextDueDate ? formatDateBR(c.nextDueDate, true) : '-' },
     { header: 'Cadastro', accessor: (c: SaaSClient) => formatDateBR(c.signupDate, true) },
   ];
 

--- a/server/server.js
+++ b/server/server.js
@@ -1471,7 +1471,13 @@ app.get('/api/admin/report', authenticateToken, authorizeAdmin, (req, res) => {
 
 // --- SaaS Clients Management ---
 app.get('/api/saas/clients', authenticateToken, authorizeAdmin, (req, res) => {
-  db.all('SELECT * FROM saas_clients ORDER BY signupDate DESC', [], (err, rows) => {
+  const sql = `
+    SELECT sc.*, cb.planName AS billingPlanName, cb.lastPaymentDate, cb.nextDueDate,
+           cb.status AS billingStatus
+    FROM saas_clients sc
+    LEFT JOIN client_billing cb ON cb.clientId = sc.id
+    ORDER BY sc.signupDate DESC`;
+  db.all(sql, [], (err, rows) => {
     if (err) {
       console.error('Error fetching SaaS clients:', err.message);
       return res.status(500).json({ message: 'Failed to fetch clients.' });

--- a/types.ts
+++ b/types.ts
@@ -285,6 +285,10 @@ export interface SaaSClient {
   subscriptionPlan: string;
   subscriptionStatus: 'active' | 'trial' | 'canceled';
   signupDate: string; // ISO date string
+  billingPlanName?: string;
+  lastPaymentDate?: string;
+  nextDueDate?: string;
+  billingStatus?: string;
 }
 
 export interface SubscriptionPlan {


### PR DESCRIPTION
## Summary
- join billing info when listing SaaS clients on the server
- expose billing fields in `SaaSClient` type
- show plan and due date columns in SaaS clients admin page
- add SaaS clients page to admin sidebar
- route `/admin/clients` to SaaS client admin page

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685ae5c825cc8322afdfb673b0d62015