### PR TITLE
Fix server fetch import

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -4,7 +4,6 @@ const cors = require('cors');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const { v4: uuidv4 } = require('uuid');
-const fetch = require('node-fetch');
 const fs = require('fs');
 const path = require('path');
 const multer = require('multer');


### PR DESCRIPTION
## Summary
- remove `node-fetch` import in server
- rely on Node 18 global `fetch`

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685d0e96c6c883228aa5dc0d28a2ad8d