### PR TITLE
Fix root initialization when script loads early

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -2,14 +2,21 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App'; // App.tsx should have a default export: export default App;
 
-const rootElement = document.getElementById('root');
-if (!rootElement) {
-  throw new Error("Elemento root não encontrado no DOM.");
-}
+const renderApp = () => {
+  const rootElement = document.getElementById('root');
+  if (!rootElement) {
+    throw new Error('Elemento root não encontrado no DOM.');
+  }
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+};
 
-const root = ReactDOM.createRoot(rootElement);
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+if (document.readyState === 'loading') {
+  window.addEventListener('DOMContentLoaded', renderApp);
+} else {
+  renderApp();
+}


### PR DESCRIPTION
## Summary
- ensure `index.tsx` waits for DOMContentLoaded before mounting React

## Testing
- `npm run build`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685d11a510a483229a7a4c9042b985b7