### PR TITLE
Fix TodayTasksDisplay handling of empty task list

### DIFF
--- a/features/Dashboard/Home.tsx
+++ b/features/Dashboard/Home.tsx
@@ -33,7 +33,8 @@ const TodayTasksDisplay: React.FC = () => {
     const fetchTasks = async () => {
       setIsLoading(true);
       try {
-        setTasks(await getTodaysTasks());
+        const fetched = await getTodaysTasks();
+        setTasks(Array.isArray(fetched) ? fetched : []);
       } catch (e) {
         console.error("Failed to fetch today's tasks", e);
       } finally {


### PR DESCRIPTION
## Summary
- ensure TodayTasksDisplay uses an empty array when the dashboard API returns no tasks

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685d77919e3083228da8df8321f54ba9